### PR TITLE
Add bromazepam effect thresholds

### DIFF
--- a/BromazepamPage.xaml
+++ b/BromazepamPage.xaml
@@ -277,6 +277,16 @@
                             </chart:SplineSeries>
                         </chart:SfCartesianChart>
                     </Frame>
+                    <Label x:Name="EffectStatus"
+                           FontSize="14"
+                           HorizontalOptions="Center"
+                           TextColor="Green"
+                           Text=""/>
+                    <Label x:Name="EffectPrediction"
+                           FontSize="12"
+                           HorizontalOptions="Center"
+                           TextColor="Red"
+                           Text=""/>
 
                 </VerticalStackLayout>
             </Frame>

--- a/BromazepamPage.xaml.cs
+++ b/BromazepamPage.xaml.cs
@@ -21,6 +21,10 @@ namespace MoleculeEfficienceTracker
         protected override SfCartesianChart ChartControl => ConcentrationChart;
         protected override CollectionView DosesDisplayCollection => DosesCollection;
         protected override Label EmptyStateIndicatorLabel => EmptyDosesLabel;
+
+        // Labels spécifiques à l'effet
+        private Label EffectStatusLabel => EffectStatus;
+        private Label EffectEndPredictionLabel => EffectPrediction;
         
 
         protected override string DoseAnnotationIcon => "💊";
@@ -35,6 +39,80 @@ namespace MoleculeEfficienceTracker
         {
             InitializeComponent();
             base.InitializePageUI();
+        }
+
+        protected override void UpdateMoleculeSpecificConcentrationInfo(List<DoseEntry> doses, DateTime currentTime)
+        {
+            if (Calculator is BromazepamCalculator calc)
+            {
+                double concentration = calc.CalculateTotalConcentration(doses, currentTime);
+                var level = calc.GetEffectLevel(concentration);
+
+                string text = level switch
+                {
+                    BromazepamCalculator.EffectLevel.Strong => "Effet anxiolytique fort",
+                    BromazepamCalculator.EffectLevel.Moderate => "Effet anxiolytique modéré",
+                    BromazepamCalculator.EffectLevel.Light => "Effet anxiolytique très léger",
+                    _ => "Effet négligeable"
+                };
+
+                Color color = level switch
+                {
+                    BromazepamCalculator.EffectLevel.Strong => Colors.Green,
+                    BromazepamCalculator.EffectLevel.Moderate => Colors.Green,
+                    BromazepamCalculator.EffectLevel.Light => Colors.Orange,
+                    _ => Colors.Red
+                };
+
+                if (EffectStatusLabel != null)
+                {
+                    EffectStatusLabel.Text = text;
+                    EffectStatusLabel.TextColor = color;
+                    EffectStatusLabel.IsVisible = true;
+                }
+
+                DateTime? endTime = calc.PredictEffectEndTime(doses, currentTime);
+                if (EffectEndPredictionLabel != null)
+                {
+                    if (endTime.HasValue && endTime.Value > currentTime)
+                    {
+                        var remaining = endTime.Value - currentTime;
+                        EffectEndPredictionLabel.Text = $"Effet négligeable estimé dans {remaining.TotalHours:F1} heures";
+                    }
+                    else
+                    {
+                        EffectEndPredictionLabel.Text = "Effet actuellement négligeable";
+                    }
+                    EffectEndPredictionLabel.IsVisible = true;
+                }
+            }
+        }
+
+        protected override void AddMoleculeSpecificChartAnnotations()
+        {
+            if (Calculator is BromazepamCalculator calc && ChartControl != null)
+            {
+                var threshold = BromazepamCalculator.NEGLIGIBLE_THRESHOLD;
+                var annotation = new HorizontalLineAnnotation
+                {
+                    Y1 = threshold,
+                    Stroke = Brush.Red,
+                    StrokeWidth = 2,
+                    StrokeDashArray = new DoubleCollection { 5, 5 },
+                    Text = "Seuil de perception",
+                    LabelStyle = new ChartAnnotationLabelStyle
+                    {
+                        FontSize = 10,
+                        TextColor = Colors.Red,
+                        Background = Brush.White,
+                        CornerRadius = 3,
+                        HorizontalTextAlignment = ChartLabelAlignment.Start,
+                        VerticalTextAlignment = ChartLabelAlignment.Center,
+                        Margin = new Thickness(5, 0, 0, 0)
+                    }
+                };
+                ChartControl.Annotations.Add(annotation);
+            }
         }
 
         protected override async Task OnBeforeLoadDataAsync()


### PR DESCRIPTION
## Summary
- model bromazepam effect levels and prediction helpers
- display effect level and prediction on Bromazepam page
- show threshold line on the chart

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414c0d7ff48330a46e137b1fa2828e