### PR TITLE
Add bromazepam effect thresholds

### DIFF
--- a/BromazepamPage.xaml
+++ b/BromazepamPage.xaml
@@ -277,6 +277,16 @@
                             </chart:SplineSeries>
                         </chart:SfCartesianChart>
                     </Frame>
+                    <Label x:Name="EffectStatus"
+                           FontSize="14"
+                           HorizontalOptions="Center"
+                           TextColor="Green"
+                           Text=""/>
+                    <Label x:Name="EffectPrediction"
+                           FontSize="12"
+                           HorizontalOptions="Center"
+                           TextColor="Red"
+                           Text=""/>
 
                 </VerticalStackLayout>
             </Frame>


### PR DESCRIPTION
## Summary
- model bromazepam effect levels and prediction helpers
- display effect level and prediction on Bromazepam page
- show threshold line on the chart
- fix effect level enum usage

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414c0d7ff48330a46e137b1fa2828e