### PR TITLE
Add configurable user weight

### DIFF
--- a/BaseMoleculePage.cs
+++ b/BaseMoleculePage.cs
@@ -141,7 +141,8 @@ namespace MoleculeEfficienceTracker
                 TimeSpan selectedTime = TimePickerControl.Time;
                 DateTime dateTime = selectedDate.Add(selectedTime);
 
-                DoseEntry dose = new DoseEntry(dateTime, doseMg);
+                double weight = UserPreferences.GetWeightKg();
+                DoseEntry dose = new DoseEntry(dateTime, doseMg, weight);
 
                 Doses.Insert(0, dose);
                 DoseInputControl.Text = "";

--- a/Core/Services/UserPreferences.cs
+++ b/Core/Services/UserPreferences.cs
@@ -1,0 +1,20 @@
+using Microsoft.Maui.Storage;
+
+namespace MoleculeEfficienceTracker.Core.Services
+{
+    public static class UserPreferences
+    {
+        private const string WeightKey = "user_weight_kg";
+        private const double DefaultWeight = 72.0;
+
+        public static double GetWeightKg()
+        {
+            return Preferences.Get(WeightKey, DefaultWeight);
+        }
+
+        public static void SetWeightKg(double weightKg)
+        {
+            Preferences.Set(WeightKey, weightKg);
+        }
+    }
+}

--- a/MainTabsPage.xaml
+++ b/MainTabsPage.xaml
@@ -21,4 +21,6 @@
 
     <!-- Onglet Alcool -->
     <local:AlcoholPage Title="Alcool" IconImageSource="🍾" />
+    <!-- Onglet Paramètres -->
+    <local:SettingsPage Title="Réglages" IconImageSource="⚙️" />
 </TabbedPage>

--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ MoleculeEfficienceTracker est une application mobile multiplateforme développé
 
 ### 📊 Fonctionnalités principales
 - **Suivi des doses** : Enregistrement avec date/heure précise
-- **Calculs pharmacocinétiques** : Modèle 1 compartiment (absorption/élimination du 1er ordre) prenant en compte le poids (72 kg par défaut) et le volume de distribution
+ - **Calculs pharmacocinétiques** : Modèle 1 compartiment (absorption/élimination du 1er ordre) prenant en compte le poids (configurable, 72 kg par défaut) et le volume de distribution
 - **Graphiques temps réel** : Visualisation interactive avec annotations (Syncfusion Charts)
 - **Seuils d'efficacité** : Prédictions personnalisées (ex: seuil caféine à 35mg)
 - **Sauvegarde automatique** : Persistance JSON locale
 - **Export de données** : Sauvegarde au format JSON
 - **Interface intuitive** : Navigation par onglets avec design moderne
+- **Réglage du poids utilisateur** : saisie du poids personnel utilisé dans les calculs
 
 ### 🔬 Modèle mathématique
 

--- a/SettingsPage.xaml
+++ b/SettingsPage.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MoleculeEfficienceTracker.SettingsPage"
+             Title="Paramètres">
+    <VerticalStackLayout Spacing="20" Padding="20">
+        <Label Text="Poids (kg)" FontAttributes="Bold" />
+        <Entry x:Name="WeightEntry" Keyboard="Numeric" Placeholder="72" />
+        <Button Text="Enregistrer" Clicked="OnSaveClicked" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/SettingsPage.xaml.cs
+++ b/SettingsPage.xaml.cs
@@ -1,0 +1,32 @@
+using Microsoft.Maui.Controls;
+using MoleculeEfficienceTracker.Core.Services;
+
+namespace MoleculeEfficienceTracker
+{
+    public partial class SettingsPage : ContentPage
+    {
+        public SettingsPage()
+        {
+            InitializeComponent();
+        }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            WeightEntry.Text = UserPreferences.GetWeightKg().ToString("F1");
+        }
+
+        private async void OnSaveClicked(object sender, EventArgs e)
+        {
+            if (double.TryParse(WeightEntry.Text, out double weight) && weight > 0)
+            {
+                UserPreferences.SetWeightKg(weight);
+                await DisplayAlert("✅", "Poids enregistré", "OK");
+            }
+            else
+            {
+                await DisplayAlert("❌", "Entrez un poids valide", "OK");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `UserPreferences` service for storing weight
- add settings page to edit weight
- integrate weight preference when adding doses
- link settings page in tabbed navigation
- document weight customization in README

## Testing
- `dotnet build -v minimal` *(fails: workloads missing)*

------
https://chatgpt.com/codex/tasks/task_e_68418ee5be848330b8e6fc6706177246