### PR TITLE
Improve mobile layout and effect visibility

### DIFF
--- a/Alcohol.xaml
+++ b/Alcohol.xaml
@@ -117,7 +117,7 @@
 
             <!-- HEADER -->
             <Label Text="📊 Calculateur de Alcool"
-                   FontSize="32"
+                   FontSize="24"
                    TextColor="#2D3748"
                    HorizontalOptions="Center"
                    FontAttributes="Bold"
@@ -127,9 +127,9 @@
             <!-- AJOUTER UNE DOSE -->
             <Frame Style="{StaticResource CardFrameStyle}"
                    Margin="0,0,0,0">
-                <VerticalStackLayout Spacing="14">
+                <VerticalStackLayout Spacing="10">
                     <Label Text="🍾 Ajouter une dose"
-                           FontSize="20"
+                           FontSize="16"
                            FontAttributes="Bold"
                            TextColor="#3182CE"/>
                     <Grid ColumnDefinitions="Auto,*"
@@ -147,12 +147,12 @@
                                BackgroundColor="#EBF8FF"
                                HasShadow="False"
                                VerticalOptions="Center"
-                               HeightRequest="38">
+                               HeightRequest="32">
                             <Entry x:Name="DoseEntry"
                                    Placeholder="3.0"
                                    Keyboard="Numeric"
                                    BackgroundColor="Transparent"
-                                   HeightRequest="38"
+                                   HeightRequest="32"
                                    VerticalOptions="Center"/>
                         </Frame>
                         <Label Grid.Row="1"

--- a/BromazepamPage.xaml
+++ b/BromazepamPage.xaml
@@ -113,7 +113,7 @@
 
             <!-- HEADER -->
             <Label Text="📊 Calculateur de Bromazépam"
-                   FontSize="32"
+                   FontSize="24"
                    TextColor="#2D3748"
                    HorizontalOptions="Center"
                    FontAttributes="Bold"
@@ -123,9 +123,9 @@
             <!-- AJOUTER UNE DOSE -->
             <Frame Style="{StaticResource CardFrameStyle}"
                    Margin="0,0,0,0">
-                <VerticalStackLayout Spacing="14">
+                <VerticalStackLayout Spacing="10">
                     <Label Text="💊 Ajouter une dose"
-                           FontSize="20"
+                           FontSize="16"
                            FontAttributes="Bold"
                            TextColor="#3182CE"/>
                     <Grid ColumnDefinitions="Auto,*"
@@ -143,12 +143,12 @@
                                BackgroundColor="#EBF8FF"
                                HasShadow="False"
                                VerticalOptions="Center"
-                               HeightRequest="38">
+                               HeightRequest="32">
                             <Entry x:Name="DoseEntry"
                                    Placeholder="3.0"
                                    Keyboard="Numeric"
                                    BackgroundColor="Transparent"
-                                   HeightRequest="38"
+                                   HeightRequest="32"
                                    VerticalOptions="Center"/>
                         </Frame>
                         <Label Grid.Row="1"
@@ -187,6 +187,16 @@
                            FontSize="14"
                            TextColor="#718096"
                            HorizontalOptions="Center"/>
+                    <Label x:Name="EffectStatus"
+                           FontSize="14"
+                           HorizontalOptions="Center"
+                           TextColor="Green"
+                           Text=""/>
+                    <Label x:Name="EffectPrediction"
+                           FontSize="12"
+                           HorizontalOptions="Center"
+                           TextColor="Red"
+                           Text=""/>
                     <Frame Padding="10"
                            CornerRadius="10"
                            BackgroundColor="White"
@@ -277,16 +287,6 @@
                             </chart:SplineSeries>
                         </chart:SfCartesianChart>
                     </Frame>
-                    <Label x:Name="EffectStatus"
-                           FontSize="14"
-                           HorizontalOptions="Center"
-                           TextColor="Green"
-                           Text=""/>
-                    <Label x:Name="EffectPrediction"
-                           FontSize="12"
-                           HorizontalOptions="Center"
-                           TextColor="Red"
-                           Text=""/>
 
                 </VerticalStackLayout>
             </Frame>

--- a/CaffeinePage.xaml
+++ b/CaffeinePage.xaml
@@ -113,7 +113,7 @@
 
             <!-- HEADER -->
             <Label Text="📊 Calculateur de Caféine"
-                   FontSize="32"
+                   FontSize="24"
                    TextColor="#2D3748"
                    HorizontalOptions="Center"
                    FontAttributes="Bold"
@@ -123,9 +123,9 @@
             <!-- AJOUTER UNE DOSE -->
             <Frame Style="{StaticResource CardFrameStyle}"
                    Margin="0,0,0,0">
-                <VerticalStackLayout Spacing="14">
+                <VerticalStackLayout Spacing="10">
                     <Label Text="🍵 Ajouter une dose"
-                           FontSize="20"
+                           FontSize="16"
                            FontAttributes="Bold"
                            TextColor="#3182CE"/>
                     <Grid ColumnDefinitions="Auto,*"
@@ -144,12 +144,12 @@
                                BackgroundColor="#EBF8FF"
                                HasShadow="False"
                                VerticalOptions="Center"
-                               HeightRequest="38">
+                               HeightRequest="32">
                             <Entry x:Name="DoseEntry"
                                    Placeholder="1.0 (= 1 Nespresso)"
                                    Keyboard="Numeric"
                                    BackgroundColor="Transparent"
-                                   HeightRequest="38"
+                                   HeightRequest="32"
                                    VerticalOptions="Center"/>
                         </Frame>
                     </Grid>
@@ -197,6 +197,11 @@
                     <Label x:Name="LastUpdateLabel"
                            FontSize="14"
                            TextColor="#718096"
+                           HorizontalOptions="Center"/>
+                    <Label x:Name="IneffectiveTimeLabel"
+                           Text=""
+                           FontSize="12"
+                           TextColor="Red"
                            HorizontalOptions="Center"/>
                     <Frame Padding="10"
                            CornerRadius="10"
@@ -288,11 +293,6 @@
                             </chart:SplineSeries>
                         </chart:SfCartesianChart>
                     </Frame>
-                    <Label x:Name="IneffectiveTimeLabel"
-                           Text=""
-                           FontSize="12"
-                           TextColor="Red"
-                           HorizontalOptions="Center"/>
 
                 </VerticalStackLayout>
             </Frame>

--- a/IbuprofenePage.xaml
+++ b/IbuprofenePage.xaml
@@ -113,7 +113,7 @@
 
             <!-- HEADER -->
             <Label Text="📊 Calculateur de Ibuprofène"
-                   FontSize="32"
+                   FontSize="24"
                    TextColor="#2D3748"
                    HorizontalOptions="Center"
                    FontAttributes="Bold"
@@ -123,9 +123,9 @@
             <!-- AJOUTER UNE DOSE -->
             <Frame Style="{StaticResource CardFrameStyle}"
                    Margin="0,0,0,0">
-                <VerticalStackLayout Spacing="14">
+                <VerticalStackLayout Spacing="10">
                     <Label Text="💊 Ajouter une dose"
-                           FontSize="20"
+                           FontSize="16"
                            FontAttributes="Bold"
                            TextColor="#3182CE"/>
                     <Grid ColumnDefinitions="Auto,*"
@@ -143,12 +143,12 @@
                                BackgroundColor="#EBF8FF"
                                HasShadow="False"
                                VerticalOptions="Center"
-                               HeightRequest="38">
+                               HeightRequest="32">
                             <Entry x:Name="DoseEntry"
                                    Placeholder="3.0"
                                    Keyboard="Numeric"
                                    BackgroundColor="Transparent"
-                                   HeightRequest="38"
+                                   HeightRequest="32"
                                    VerticalOptions="Center"/>
                         </Frame>
                         <Label Grid.Row="1"

--- a/ParacetamolPage.xaml
+++ b/ParacetamolPage.xaml
@@ -113,7 +113,7 @@
 
             <!-- HEADER -->
             <Label Text="📊 Calculateur de Paracétamol"
-                   FontSize="32"
+                   FontSize="24"
                    TextColor="#2D3748"
                    HorizontalOptions="Center"
                    FontAttributes="Bold"
@@ -123,9 +123,9 @@
             <!-- AJOUTER UNE DOSE -->
             <Frame Style="{StaticResource CardFrameStyle}"
                    Margin="0,0,0,0">
-                <VerticalStackLayout Spacing="14">
+                <VerticalStackLayout Spacing="10">
                     <Label Text="💊 Ajouter une dose"
-                           FontSize="20"
+                           FontSize="16"
                            FontAttributes="Bold"
                            TextColor="#3182CE"/>
                     <Grid ColumnDefinitions="Auto,*"
@@ -143,12 +143,12 @@
                                BackgroundColor="#EBF8FF"
                                HasShadow="False"
                                VerticalOptions="Center"
-                               HeightRequest="38">
+                               HeightRequest="32">
                             <Entry x:Name="DoseEntry"
                                    Placeholder="3.0"
                                    Keyboard="Numeric"
                                    BackgroundColor="Transparent"
-                                   HeightRequest="38"
+                                   HeightRequest="32"
                                    VerticalOptions="Center"/>
                         </Frame>
                         <Label Grid.Row="1"


### PR DESCRIPTION
## Summary
- shrink headers and dose input cards
- move effect description labels above chart for better readability
- adjust input field heights for compact display

## Testing
- `dotnet build` *(fails: NETSDK1147 workloads not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68419686477c8330b1ff834de0259595