### PR TITLE
Fix caffeine annotation units

### DIFF
--- a/BaseMoleculePage.cs
+++ b/BaseMoleculePage.cs
@@ -45,6 +45,7 @@ namespace MoleculeEfficienceTracker
         protected abstract int GraphDataNumberOfPoints { get; } // Ex: 10 * 24 * 2
         protected abstract TimeSpan InitialVisibleStartOffset { get; } // Ex: TimeSpan.FromHours(-12)
         protected abstract TimeSpan InitialVisibleEndOffset { get; }   // Ex: TimeSpan.FromHours(24)
+        protected virtual bool UseConcentrationUnitForDoseAnnotation => false;
         public bool HasDoses => Doses != null && Doses.Count > 0;
         public bool IsDosesListEmpty => Doses == null || Doses.Count == 0; // Ou simplement !HasDoses
 
@@ -317,7 +318,8 @@ namespace MoleculeEfficienceTracker
             {
                 double concentrationAtDoseTime = Calculator.CalculateTotalConcentration(currentDoses, dose.TimeTaken);
                 double displayValue = Calculator.GetDoseDisplayValueInConcentrationUnit(dose);
-                string doseText = $"{DoseAnnotationIcon}{displayValue:F2}{Calculator.DoseUnit}";
+                string unit = UseConcentrationUnitForDoseAnnotation ? Calculator.ConcentrationUnit : Calculator.DoseUnit;
+                string doseText = $"{DoseAnnotationIcon}{displayValue:F2}{unit}";
 
                 TextAnnotation doseAnnotation = new TextAnnotation
                 {

--- a/CaffeinePage.xaml.cs
+++ b/CaffeinePage.xaml.cs
@@ -29,6 +29,7 @@ namespace MoleculeEfficienceTracker
         protected override int GraphDataNumberOfPoints => 10 * 24 * 2; // 10 jours, 2 points par heure
         protected override TimeSpan InitialVisibleStartOffset => TimeSpan.FromHours(-24); // Vue initiale de -24h
         protected override TimeSpan InitialVisibleEndOffset => TimeSpan.FromHours(24);   // Vue initiale de +24h
+        protected override bool UseConcentrationUnitForDoseAnnotation => true;
 
         public CaffeinePage()
             : base("caffeine") // Utiliser une clé en minuscules pour la cohérence


### PR DESCRIPTION
## Summary
- allow using concentration unit for dose annotations
- enable this feature on the caffeine page

## Testing
- `dotnet build -v minimal` *(fails: missing MAUI workloads)*

------
https://chatgpt.com/codex/tasks/task_e_6841a390d3f88330b9f8a86ad9fef185