### PR TITLE
Fix caffeine dose annotation

### DIFF
--- a/CaffeinePage.xaml.cs
+++ b/CaffeinePage.xaml.cs
@@ -33,7 +33,7 @@ namespace MoleculeEfficienceTracker
         protected override int GraphDataNumberOfPoints => 10 * 24 * 2; // 10 jours, 2 points par heure
         protected override TimeSpan InitialVisibleStartOffset => TimeSpan.FromHours(-24); // Vue initiale de -24h
         protected override TimeSpan InitialVisibleEndOffset => TimeSpan.FromHours(24);   // Vue initiale de +24h
-        protected override bool UseConcentrationUnitForDoseAnnotation => true;
+        protected override bool UseConcentrationUnitForDoseAnnotation => false;
 
         public CaffeinePage()
             : base("caffeine") // Utiliser une clé en minuscules pour la cohérence


### PR DESCRIPTION
## Summary
- fix caffeine page dose annotation to use mg instead of mg/L

## Testing
- `dotnet build MoleculeEfficienceTracker.sln -consoleloggerparameters:DisableConsoleColor` *(fails: InternalLoggerException)*

------
https://chatgpt.com/codex/tasks/task_e_6841a8967b1883309a5654964b4ffc7e