### PR TITLE
Caffeine dose input in mg

### DIFF
--- a/CaffeinePage.xaml
+++ b/CaffeinePage.xaml
@@ -134,7 +134,7 @@
                           RowSpacing="12">
                         <Label Grid.Row="0"
                                Grid.Column="0"
-                               Text="Dose (u):"
+                               Text="Dose (mg):"
                                VerticalOptions="Center"/>
 
                         <Frame Grid.Row="0"
@@ -146,14 +146,14 @@
                                VerticalOptions="Center"
                                HeightRequest="32">
                             <Entry x:Name="DoseEntry"
-                                   Placeholder="1.0 (= 1 Nespresso)"
+                                   Placeholder="80 (= 1 Nespresso)"
                                    Keyboard="Numeric"
                                    BackgroundColor="Transparent"
                                    HeightRequest="32"
                                    VerticalOptions="Center"/>
                         </Frame>
                     </Grid>
-                    <Label Text="Exemples: Nespresso = 1.0, Lungo = 1.2, Tasse =  1.2, Coca-Cola = 0.4, Thé = 0.6"
+                    <Label Text="Exemples: Nespresso = 80 mg, Lungo = 95 mg, Tasse = 95 mg, Coca-Cola = 35 mg, Thé = 47 mg"
                            FontSize="10"
                            TextColor="#718096"
                            Margin="70,-20,0,0"/>

--- a/CaffeinePage.xaml.cs
+++ b/CaffeinePage.xaml.cs
@@ -129,5 +129,27 @@ namespace MoleculeEfficienceTracker
 
             ChartControl.Annotations.Add(annotation);
         }
+
+        protected override async Task OnBeforeLoadDataAsync()
+        {
+            await base.OnBeforeLoadDataAsync();
+
+            List<DoseEntry> existing = await PersistenceService.LoadDosesAsync();
+            bool converted = false;
+
+            foreach (DoseEntry d in existing)
+            {
+                if (d.DoseMg > 0 && d.DoseMg < 20)
+                {
+                    d.DoseMg *= CaffeineCalculator.MG_PER_UNIT;
+                    converted = true;
+                }
+            }
+
+            if (converted)
+            {
+                await PersistenceService.SaveDosesAsync(existing);
+            }
+        }
     }
 }

--- a/CaffeinePage.xaml.cs
+++ b/CaffeinePage.xaml.cs
@@ -49,9 +49,8 @@ namespace MoleculeEfficienceTracker
             {
                 double concentration = caffeineCalc.CalculateTotalConcentration(doses, currentTime);
                 double totalMg = caffeineCalc.CalculateTotalAmount(doses, currentTime);
-                double totalUnits = totalMg / CaffeineCalculator.MG_PER_UNIT;
 
-                ConcentrationOutputLabel.Text = $"{totalUnits:F1}u ({totalMg:F0} mg, {concentration:F2} {Calculator.ConcentrationUnit})";
+                ConcentrationOutputLabel.Text = $"{totalMg:F0} mg ({concentration:F2} {Calculator.ConcentrationUnit})";
 
                 var level = caffeineCalc.GetEffectLevel(concentration);
 

--- a/Core/Services/CaffeineCalculator.cs
+++ b/Core/Services/CaffeineCalculator.cs
@@ -8,7 +8,7 @@ namespace MoleculeEfficienceTracker.Core.Services
     public class CaffeineCalculator : IMoleculeCalculator
     {
         public string DisplayName => "Caféine";
-        public string DoseUnit => "u";
+        public string DoseUnit => "mg";
         public string ConcentrationUnit => "mg/L";
 
         // Paramètres pharmacocinétiques de la caféine
@@ -51,7 +51,7 @@ namespace MoleculeEfficienceTracker.Core.Services
 
             if (hoursElapsed < 0) return 0; // Dose future
 
-            double doseMg = dose.DoseMg * MG_PER_UNIT;
+            double doseMg = dose.DoseMg;
 
             double volume = dose.WeightKg * VOLUME_DISTRIBUTION_L_PER_KG;
 
@@ -74,7 +74,8 @@ namespace MoleculeEfficienceTracker.Core.Services
         // Retourne la valeur de la dose en unité de concentration (mg pour la caféine)
         public double GetDoseDisplayValueInConcentrationUnit(DoseEntry dose)
         {
-            return dose.DoseMg * MG_PER_UNIT; // Convertit les unités entrées en mg
+            // La dose est désormais saisie directement en mg
+            return dose.DoseMg;
         }
 
         public double CalculateTotalAmount(List<DoseEntry> doses, DateTime currentTime)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ MoleculeEfficienceTracker est une application mobile multiplateforme développé
 
 ### 🧪 Molécules supportées
 - **Bromazépam** : Demi-vie 14h, absorption 2h, biodisponibilité 84%, concentration en **mg/L**
-- **Caféine** : Demi-vie 5h, absorption 45min, système d'unités (1 unité = 80mg Nespresso)
+- **Caféine** : Demi-vie 5h, absorption 45min, saisie des doses en **mg** (80 mg = 1 Nespresso)
 - **Alcool** : Élimination linéaire 1 unité/heure, absorption 45min
 - **Paracétamol** : Demi-vie 3h, absorption 30min, biodisponibilité 92%, concentration en **mg/L** *(en développement)*
 - **Ibuprofène** : Demi-vie 2h, absorption 30min, biodisponibilité 90%, concentration en **mg/L** *(en développement)*


### PR DESCRIPTION
## Summary
- change caffeine calculator to expect mg instead of units
- update caffeine UI labels and examples
- migrate existing caffeine dose data from unit-based to mg
- document caffeine dose input in mg

## Testing
- `dotnet build -c Release` *(fails: workloads missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841cca903888330bd8e36de948a1ef2