### PR TITLE
Adjust caffeine chart to show thresholds

### DIFF
--- a/BaseMoleculePage.cs
+++ b/BaseMoleculePage.cs
@@ -46,6 +46,7 @@ namespace MoleculeEfficienceTracker
         protected abstract TimeSpan InitialVisibleStartOffset { get; } // Ex: TimeSpan.FromHours(-12)
         protected abstract TimeSpan InitialVisibleEndOffset { get; }   // Ex: TimeSpan.FromHours(24)
         protected virtual bool UseConcentrationUnitForDoseAnnotation => false;
+        protected virtual double? MaxThresholdYValue => null;
         public bool HasDoses => Doses != null && Doses.Count > 0;
         public bool IsDosesListEmpty => Doses == null || Doses.Count == 0; // Ou simplement !HasDoses
 
@@ -271,6 +272,16 @@ namespace MoleculeEfficienceTracker
                     xAxis.ZoomFactor = 1;
                     xAxis.ZoomPosition = 0;
                 }
+            }
+
+            if (chart.YAxes?.FirstOrDefault() is NumericalAxis yAxis)
+            {
+                double dataMax = ChartData.Any() ? ChartData.Max(p => p.Concentration) : 0;
+                double requiredMax = Math.Max(dataMax, MaxThresholdYValue ?? dataMax);
+                if (requiredMax <= 0) requiredMax = 1;
+                yAxis.Maximum = requiredMax * 1.1;
+                yAxis.ZoomFactor = 1;
+                yAxis.ZoomPosition = 0;
             }
 
             await chart.FadeTo(0.7, 80);

--- a/CaffeinePage.xaml
+++ b/CaffeinePage.xaml
@@ -131,7 +131,7 @@
                             </chart:SfCartesianChart.TrackballBehavior>
 
                             <chart:SfCartesianChart.ZoomPanBehavior>
-                                <chart:ChartZoomPanBehavior ZoomMode="X"
+                                <chart:ChartZoomPanBehavior ZoomMode="XY"
                                                             EnablePanning="True"/>
                             </chart:SfCartesianChart.ZoomPanBehavior>
 

--- a/CaffeinePage.xaml.cs
+++ b/CaffeinePage.xaml.cs
@@ -34,6 +34,7 @@ namespace MoleculeEfficienceTracker
         protected override TimeSpan InitialVisibleStartOffset => TimeSpan.FromHours(-24); // Vue initiale de -24h
         protected override TimeSpan InitialVisibleEndOffset => TimeSpan.FromHours(24);   // Vue initiale de +24h
         protected override bool UseConcentrationUnitForDoseAnnotation => false;
+        protected override double? MaxThresholdYValue => CaffeineCalculator.STRONG_THRESHOLD;
 
         public CaffeinePage()
             : base("caffeine") // Utiliser une clé en minuscules pour la cohérence


### PR DESCRIPTION
## Summary
- expose an optional MaxThresholdYValue in the base page
- adapt chart Y-axis to include threshold values
- override MaxThresholdYValue for caffeine
- enable vertical zoom in caffeine chart

## Testing
- `dotnet build -v q` *(fails: unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_6841d921edec83309ecb8b3a38aba1ac