### PR TITLE
Improve dark mode support

### DIFF
--- a/Alcohol.xaml
+++ b/Alcohol.xaml
@@ -20,12 +20,12 @@
             <converters:DoseDisplayConverter x:Key="DoseDisplayConverter"/>
             <converters:DoseLabelConverter x:Key="DoseLabelConverter"/>
             <!-- Fond général de la page -->
-            <AppThemeColor x:Key="MainBgColor" Light="#F0F4F8" Dark="#1F1F1F"/>
-            <AppThemeColor x:Key="EntryBgColor" Light="#EBF8FF" Dark="#3A3A3A"/>
-            <AppThemeColor x:Key="ChartSectionBgColor" Light="#E6FFFA" Dark="#2D2D2D"/>
-            <AppThemeColor x:Key="ListSectionBgColor" Light="#FFFDE7" Dark="#2D2D2D"/>
-            <AppThemeColor x:Key="ItemFrameBgColor" Light="#FAF5FF" Dark="#3A3A3A"/>
-            <AppThemeColor x:Key="ExportSectionBgColor" Light="#EDF2F7" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="MainBgColor" x:TypeArguments="Color" Light="#F0F4F8" Dark="#1F1F1F"/>
+            <OnAppTheme x:Key="EntryBgColor" x:TypeArguments="Color" Light="#EBF8FF" Dark="#3A3A3A"/>
+            <OnAppTheme x:Key="ChartSectionBgColor" x:TypeArguments="Color" Light="#E6FFFA" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="ListSectionBgColor" x:TypeArguments="Color" Light="#FFFDE7" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="ItemFrameBgColor" x:TypeArguments="Color" Light="#FAF5FF" Dark="#3A3A3A"/>
+            <OnAppTheme x:Key="ExportSectionBgColor" x:TypeArguments="Color" Light="#EDF2F7" Dark="#2D2D2D"/>
         </ResourceDictionary>
     </ContentPage.Resources>
 

--- a/Alcohol.xaml
+++ b/Alcohol.xaml
@@ -20,17 +20,22 @@
             <converters:DoseDisplayConverter x:Key="DoseDisplayConverter"/>
             <converters:DoseLabelConverter x:Key="DoseLabelConverter"/>
             <!-- Fond général de la page -->
-            <Color x:Key="MainBgColor">#F0F4F8</Color>
+            <AppThemeColor x:Key="MainBgColor" Light="#F0F4F8" Dark="#1F1F1F"/>
+            <AppThemeColor x:Key="EntryBgColor" Light="#EBF8FF" Dark="#3A3A3A"/>
+            <AppThemeColor x:Key="ChartSectionBgColor" Light="#E6FFFA" Dark="#2D2D2D"/>
+            <AppThemeColor x:Key="ListSectionBgColor" Light="#FFFDE7" Dark="#2D2D2D"/>
+            <AppThemeColor x:Key="ItemFrameBgColor" Light="#FAF5FF" Dark="#3A3A3A"/>
+            <AppThemeColor x:Key="ExportSectionBgColor" Light="#EDF2F7" Dark="#2D2D2D"/>
         </ResourceDictionary>
     </ContentPage.Resources>
 
     <ContentPage.Background>
-        <SolidColorBrush Color="{StaticResource MainBgColor}"/>
+        <SolidColorBrush Color="{DynamicResource MainBgColor}"/>
     </ContentPage.Background>
 
     <ScrollView>
         <VerticalStackLayout Style="{StaticResource PageRootLayoutStyle}"
-                             BackgroundColor="{StaticResource MainBgColor}">
+                             BackgroundColor="{DynamicResource MainBgColor}">
 
             <!-- AJOUTER UNE DOSE -->
             <Frame Style="{StaticResource CardFrameStyle}"
@@ -52,7 +57,7 @@
                                Grid.Column="1"
                                CornerRadius="8"
                                Padding="0"
-                               BackgroundColor="#EBF8FF"
+                               BackgroundColor="{DynamicResource EntryBgColor}"
                                HasShadow="False"
                                VerticalOptions="Center"
                                HeightRequest="32">
@@ -84,7 +89,7 @@
 
             <!-- CONCENTRATION & GRAPHIQUE -->
             <Frame Style="{StaticResource CardFrameStyle}"
-                   BackgroundColor="#E6FFFA">
+                   BackgroundColor="{DynamicResource ChartSectionBgColor}">
                 <VerticalStackLayout Spacing="8">
                     <Label Text="Concentration actuelle"
                            FontSize="20"
@@ -101,7 +106,7 @@
                            HorizontalOptions="Center"/>
                     <Frame Padding="10"
                            CornerRadius="10"
-                           BackgroundColor="White"
+                           Style="{StaticResource CardFrameStyle}"
                            HasShadow="True"
                            Margin="0,8,0,0"
                            HeightRequest="320">
@@ -195,7 +200,7 @@
 
             <!-- LISTE DES DOSES -->
             <Frame Style="{StaticResource CardFrameStyle}"
-                   BackgroundColor="#FFFDE7">
+                   BackgroundColor="{DynamicResource ListSectionBgColor}">
                 <VerticalStackLayout Spacing="8">
                     <Label Text="Doses récentes"
                            FontSize="20"
@@ -215,7 +220,7 @@
                                         IsVisible="{Binding HasDoses}"> <!-- Lier à une propriété booléenne -->
                             <CollectionView.ItemTemplate>
                                 <DataTemplate>
-                                    <Frame BackgroundColor="#FAF5FF"
+                                    <Frame BackgroundColor="{DynamicResource ItemFrameBgColor}"
                                            CornerRadius="8"
                                            Padding="0"
                                            Margin="0,3"
@@ -250,7 +255,7 @@
             <!-- BOUTONS EXPORT/RESET -->
             <Frame Style="{StaticResource CardFrameStyle}"
                    Padding="12"
-                   BackgroundColor="#EDF2F7">
+                   BackgroundColor="{DynamicResource ExportSectionBgColor}">
                 <HorizontalStackLayout Spacing="22"
                                        HorizontalOptions="Center">
                     <Button Text="💾 Exporter"

--- a/BromazepamPage.xaml
+++ b/BromazepamPage.xaml
@@ -15,12 +15,12 @@
                 <ResourceDictionary Source="Resources/Styles/ModernStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <!-- Fond général de la page -->
-            <AppThemeColor x:Key="MainBgColor" Light="#F0F4F8" Dark="#1F1F1F"/>
-            <AppThemeColor x:Key="EntryBgColor" Light="#EBF8FF" Dark="#3A3A3A"/>
-            <AppThemeColor x:Key="ChartSectionBgColor" Light="#E6FFFA" Dark="#2D2D2D"/>
-            <AppThemeColor x:Key="ListSectionBgColor" Light="#FFFDE7" Dark="#2D2D2D"/>
-            <AppThemeColor x:Key="ItemFrameBgColor" Light="#FAF5FF" Dark="#3A3A3A"/>
-            <AppThemeColor x:Key="ExportSectionBgColor" Light="#EDF2F7" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="MainBgColor" x:TypeArguments="Color" Light="#F0F4F8" Dark="#1F1F1F"/>
+            <OnAppTheme x:Key="EntryBgColor" x:TypeArguments="Color" Light="#EBF8FF" Dark="#3A3A3A"/>
+            <OnAppTheme x:Key="ChartSectionBgColor" x:TypeArguments="Color" Light="#E6FFFA" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="ListSectionBgColor" x:TypeArguments="Color" Light="#FFFDE7" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="ItemFrameBgColor" x:TypeArguments="Color" Light="#FAF5FF" Dark="#3A3A3A"/>
+            <OnAppTheme x:Key="ExportSectionBgColor" x:TypeArguments="Color" Light="#EDF2F7" Dark="#2D2D2D"/>
         </ResourceDictionary>
     </ContentPage.Resources>
 

--- a/BromazepamPage.xaml
+++ b/BromazepamPage.xaml
@@ -15,17 +15,22 @@
                 <ResourceDictionary Source="Resources/Styles/ModernStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <!-- Fond général de la page -->
-            <Color x:Key="MainBgColor">#F0F4F8</Color>
+            <AppThemeColor x:Key="MainBgColor" Light="#F0F4F8" Dark="#1F1F1F"/>
+            <AppThemeColor x:Key="EntryBgColor" Light="#EBF8FF" Dark="#3A3A3A"/>
+            <AppThemeColor x:Key="ChartSectionBgColor" Light="#E6FFFA" Dark="#2D2D2D"/>
+            <AppThemeColor x:Key="ListSectionBgColor" Light="#FFFDE7" Dark="#2D2D2D"/>
+            <AppThemeColor x:Key="ItemFrameBgColor" Light="#FAF5FF" Dark="#3A3A3A"/>
+            <AppThemeColor x:Key="ExportSectionBgColor" Light="#EDF2F7" Dark="#2D2D2D"/>
         </ResourceDictionary>
     </ContentPage.Resources>
 
     <ContentPage.Background>
-        <SolidColorBrush Color="{StaticResource MainBgColor}"/>
+        <SolidColorBrush Color="{DynamicResource MainBgColor}"/>
     </ContentPage.Background>
 
     <ScrollView>
         <VerticalStackLayout Style="{StaticResource PageRootLayoutStyle}"
-                             BackgroundColor="{StaticResource MainBgColor}">
+                             BackgroundColor="{DynamicResource MainBgColor}">
 
             <!-- AJOUTER UNE DOSE -->
             <Frame Style="{StaticResource CardFrameStyle}"
@@ -47,7 +52,7 @@
                                Grid.Column="1"
                                CornerRadius="8"
                                Padding="0"
-                               BackgroundColor="#EBF8FF"
+                               BackgroundColor="{DynamicResource EntryBgColor}"
                                HasShadow="False"
                                VerticalOptions="Center"
                                HeightRequest="32">
@@ -79,7 +84,7 @@
 
             <!-- CONCENTRATION & GRAPHIQUE -->
             <Frame Style="{StaticResource CardFrameStyle}"
-                   BackgroundColor="#E6FFFA">
+                   BackgroundColor="{DynamicResource ChartSectionBgColor}">
                 <VerticalStackLayout Spacing="8">
                     <Label Text="Concentration actuelle"
                            FontSize="20"
@@ -106,7 +111,7 @@
                            Text=""/>
                     <Frame Padding="10"
                            CornerRadius="10"
-                           BackgroundColor="White"
+                           Style="{StaticResource CardFrameStyle}"
                            HasShadow="True"
                            Margin="0,8,0,0"
                            HeightRequest="320">
@@ -200,7 +205,7 @@
 
             <!-- LISTE DES DOSES -->
             <Frame Style="{StaticResource CardFrameStyle}"
-                   BackgroundColor="#FFFDE7">
+                   BackgroundColor="{DynamicResource ListSectionBgColor}">
                 <VerticalStackLayout Spacing="8">
                     <Label Text="Doses récentes"
                            FontSize="20"
@@ -220,8 +225,8 @@
                                         IsVisible="True">
                             <CollectionView.ItemTemplate>
                                 <DataTemplate>
-                                    <Frame BackgroundColor="#FAF5FF"
-                                           CornerRadius="8"                                           
+                                    <Frame BackgroundColor="{DynamicResource ItemFrameBgColor}"
+                                           CornerRadius="8"
                                            Padding="10,6"
                                            Margin="0,3"
                                            HasShadow="False">
@@ -256,7 +261,7 @@
             <!-- BOUTONS EXPORT/RESET -->
             <Frame Style="{StaticResource CardFrameStyle}"
                    Padding="12"
-                   BackgroundColor="#EDF2F7">
+                   BackgroundColor="{DynamicResource ExportSectionBgColor}">
                 <HorizontalStackLayout Spacing="22"
                                        HorizontalOptions="Center">
                     <Button Text="💾 Exporter"

--- a/CaffeinePage.xaml
+++ b/CaffeinePage.xaml
@@ -15,17 +15,22 @@
                 <ResourceDictionary Source="Resources/Styles/ModernStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <!-- Fond général de la page -->
-            <Color x:Key="MainBgColor">#F0F4F8</Color>
+            <AppThemeColor x:Key="MainBgColor" Light="#F0F4F8" Dark="#1F1F1F"/>
+            <AppThemeColor x:Key="EntryBgColor" Light="#EBF8FF" Dark="#3A3A3A"/>
+            <AppThemeColor x:Key="ChartSectionBgColor" Light="#E6FFFA" Dark="#2D2D2D"/>
+            <AppThemeColor x:Key="ListSectionBgColor" Light="#FFFDE7" Dark="#2D2D2D"/>
+            <AppThemeColor x:Key="ItemFrameBgColor" Light="#FAF5FF" Dark="#3A3A3A"/>
+            <AppThemeColor x:Key="ExportSectionBgColor" Light="#EDF2F7" Dark="#2D2D2D"/>
         </ResourceDictionary>
     </ContentPage.Resources>
 
     <ContentPage.Background>
-        <SolidColorBrush Color="{StaticResource MainBgColor}"/>
+        <SolidColorBrush Color="{DynamicResource MainBgColor}"/>
     </ContentPage.Background>
 
     <ScrollView>
         <VerticalStackLayout Style="{StaticResource PageRootLayoutStyle}"
-                             BackgroundColor="{StaticResource MainBgColor}">
+                             BackgroundColor="{DynamicResource MainBgColor}">
 
             <!-- AJOUTER UNE DOSE -->
             <Frame Style="{StaticResource CardFrameStyle}"
@@ -48,7 +53,7 @@
                                Grid.Column="1"
                                CornerRadius="8"
                                Padding="0"
-                               BackgroundColor="#EBF8FF"
+                               BackgroundColor="{DynamicResource EntryBgColor}"
                                HasShadow="False"
                                VerticalOptions="Center"
                                HeightRequest="32">
@@ -90,7 +95,7 @@
 
             <!-- CONCENTRATION & GRAPHIQUE -->
             <Frame Style="{StaticResource CardFrameStyle}"
-                   BackgroundColor="#E6FFFA">
+                   BackgroundColor="{DynamicResource ChartSectionBgColor}">
                 <VerticalStackLayout Spacing="8">
                     <Label Text="Concentration actuelle"
                            FontSize="20"
@@ -117,7 +122,7 @@
                            HorizontalOptions="Center"/>
                     <Frame Padding="10"
                            CornerRadius="10"
-                           BackgroundColor="White"
+                           Style="{StaticResource CardFrameStyle}"
                            HasShadow="True"
                            Margin="0,8,0,0"
                            HeightRequest="320">
@@ -211,7 +216,7 @@
 
             <!-- LISTE DES DOSES -->
             <Frame Style="{StaticResource CardFrameStyle}"
-                   BackgroundColor="#FFFDE7">
+                   BackgroundColor="{DynamicResource ListSectionBgColor}">
                 <VerticalStackLayout Spacing="8">
                     <Label Text="Doses récentes"
                            FontSize="20"
@@ -231,8 +236,8 @@
                                         IsVisible="True">
                             <CollectionView.ItemTemplate>
                                 <DataTemplate>
-                                    <Frame BackgroundColor="#FAF5FF"
-                                           CornerRadius="8"                                           
+                                    <Frame BackgroundColor="{DynamicResource ItemFrameBgColor}"
+                                           CornerRadius="8"
                                            Padding="10,6"
                                            Margin="0,3"
                                            HasShadow="False">
@@ -267,7 +272,7 @@
             <!-- BOUTONS EXPORT/RESET -->
             <Frame Style="{StaticResource CardFrameStyle}"
                    Padding="12"
-                   BackgroundColor="#EDF2F7">
+                   BackgroundColor="{DynamicResource ExportSectionBgColor}">
                 <HorizontalStackLayout Spacing="22"
                                        HorizontalOptions="Center">
                     <Button Text="💾 Exporter"

--- a/CaffeinePage.xaml
+++ b/CaffeinePage.xaml
@@ -15,12 +15,12 @@
                 <ResourceDictionary Source="Resources/Styles/ModernStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <!-- Fond général de la page -->
-            <AppThemeColor x:Key="MainBgColor" Light="#F0F4F8" Dark="#1F1F1F"/>
-            <AppThemeColor x:Key="EntryBgColor" Light="#EBF8FF" Dark="#3A3A3A"/>
-            <AppThemeColor x:Key="ChartSectionBgColor" Light="#E6FFFA" Dark="#2D2D2D"/>
-            <AppThemeColor x:Key="ListSectionBgColor" Light="#FFFDE7" Dark="#2D2D2D"/>
-            <AppThemeColor x:Key="ItemFrameBgColor" Light="#FAF5FF" Dark="#3A3A3A"/>
-            <AppThemeColor x:Key="ExportSectionBgColor" Light="#EDF2F7" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="MainBgColor" x:TypeArguments="Color" Light="#F0F4F8" Dark="#1F1F1F"/>
+            <OnAppTheme x:Key="EntryBgColor" x:TypeArguments="Color" Light="#EBF8FF" Dark="#3A3A3A"/>
+            <OnAppTheme x:Key="ChartSectionBgColor" x:TypeArguments="Color" Light="#E6FFFA" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="ListSectionBgColor" x:TypeArguments="Color" Light="#FFFDE7" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="ItemFrameBgColor" x:TypeArguments="Color" Light="#FAF5FF" Dark="#3A3A3A"/>
+            <OnAppTheme x:Key="ExportSectionBgColor" x:TypeArguments="Color" Light="#EDF2F7" Dark="#2D2D2D"/>
         </ResourceDictionary>
     </ContentPage.Resources>
 

--- a/IbuprofenePage.xaml
+++ b/IbuprofenePage.xaml
@@ -15,17 +15,22 @@
                 <ResourceDictionary Source="Resources/Styles/ModernStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <!-- Fond général de la page -->
-            <Color x:Key="MainBgColor">#F0F4F8</Color>
+            <AppThemeColor x:Key="MainBgColor" Light="#F0F4F8" Dark="#1F1F1F"/>
+            <AppThemeColor x:Key="EntryBgColor" Light="#EBF8FF" Dark="#3A3A3A"/>
+            <AppThemeColor x:Key="ChartSectionBgColor" Light="#E6FFFA" Dark="#2D2D2D"/>
+            <AppThemeColor x:Key="ListSectionBgColor" Light="#FFFDE7" Dark="#2D2D2D"/>
+            <AppThemeColor x:Key="ItemFrameBgColor" Light="#FAF5FF" Dark="#3A3A3A"/>
+            <AppThemeColor x:Key="ExportSectionBgColor" Light="#EDF2F7" Dark="#2D2D2D"/>
         </ResourceDictionary>
     </ContentPage.Resources>
 
     <ContentPage.Background>
-        <SolidColorBrush Color="{StaticResource MainBgColor}"/>
+        <SolidColorBrush Color="{DynamicResource MainBgColor}"/>
     </ContentPage.Background>
 
     <ScrollView>
         <VerticalStackLayout Style="{StaticResource PageRootLayoutStyle}"
-                             BackgroundColor="{StaticResource MainBgColor}">
+                             BackgroundColor="{DynamicResource MainBgColor}">
 
             <!-- AJOUTER UNE DOSE -->
             <Frame Style="{StaticResource CardFrameStyle}"
@@ -47,7 +52,7 @@
                                Grid.Column="1"
                                CornerRadius="8"
                                Padding="0"
-                               BackgroundColor="#EBF8FF"
+                               BackgroundColor="{DynamicResource EntryBgColor}"
                                HasShadow="False"
                                VerticalOptions="Center"
                                HeightRequest="32">
@@ -79,7 +84,7 @@
 
             <!-- CONCENTRATION & GRAPHIQUE -->
             <Frame Style="{StaticResource CardFrameStyle}"
-                   BackgroundColor="#E6FFFA">
+                   BackgroundColor="{DynamicResource ChartSectionBgColor}">
                 <VerticalStackLayout Spacing="8">
                     <Label Text="Concentration actuelle"
                            FontSize="20"
@@ -96,7 +101,7 @@
                            HorizontalOptions="Center"/>
                     <Frame Padding="10"
                            CornerRadius="10"
-                           BackgroundColor="White"
+                           Style="{StaticResource CardFrameStyle}"
                            HasShadow="True"
                            Margin="0,8,0,0"
                            HeightRequest="320">
@@ -190,7 +195,7 @@
 
             <!-- LISTE DES DOSES -->
             <Frame Style="{StaticResource CardFrameStyle}"
-                   BackgroundColor="#FFFDE7">
+                   BackgroundColor="{DynamicResource ListSectionBgColor}">
                 <VerticalStackLayout Spacing="8">
                     <Label Text="Doses récentes"
                            FontSize="20"
@@ -210,8 +215,8 @@
                                         IsVisible="True">
                             <CollectionView.ItemTemplate>
                                 <DataTemplate>
-                                    <Frame BackgroundColor="#FAF5FF"
-                                           CornerRadius="8"                                           
+                                    <Frame BackgroundColor="{DynamicResource ItemFrameBgColor}"
+                                           CornerRadius="8"
                                            Padding="10,6"
                                            Margin="0,3"
                                            HasShadow="False">
@@ -246,7 +251,7 @@
             <!-- BOUTONS EXPORT/RESET -->
             <Frame Style="{StaticResource CardFrameStyle}"
                    Padding="12"
-                   BackgroundColor="#EDF2F7">
+                   BackgroundColor="{DynamicResource ExportSectionBgColor}">
                 <HorizontalStackLayout Spacing="22"
                                        HorizontalOptions="Center">
                     <Button Text="💾 Exporter"

--- a/IbuprofenePage.xaml
+++ b/IbuprofenePage.xaml
@@ -15,12 +15,12 @@
                 <ResourceDictionary Source="Resources/Styles/ModernStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <!-- Fond général de la page -->
-            <AppThemeColor x:Key="MainBgColor" Light="#F0F4F8" Dark="#1F1F1F"/>
-            <AppThemeColor x:Key="EntryBgColor" Light="#EBF8FF" Dark="#3A3A3A"/>
-            <AppThemeColor x:Key="ChartSectionBgColor" Light="#E6FFFA" Dark="#2D2D2D"/>
-            <AppThemeColor x:Key="ListSectionBgColor" Light="#FFFDE7" Dark="#2D2D2D"/>
-            <AppThemeColor x:Key="ItemFrameBgColor" Light="#FAF5FF" Dark="#3A3A3A"/>
-            <AppThemeColor x:Key="ExportSectionBgColor" Light="#EDF2F7" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="MainBgColor" x:TypeArguments="Color" Light="#F0F4F8" Dark="#1F1F1F"/>
+            <OnAppTheme x:Key="EntryBgColor" x:TypeArguments="Color" Light="#EBF8FF" Dark="#3A3A3A"/>
+            <OnAppTheme x:Key="ChartSectionBgColor" x:TypeArguments="Color" Light="#E6FFFA" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="ListSectionBgColor" x:TypeArguments="Color" Light="#FFFDE7" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="ItemFrameBgColor" x:TypeArguments="Color" Light="#FAF5FF" Dark="#3A3A3A"/>
+            <OnAppTheme x:Key="ExportSectionBgColor" x:TypeArguments="Color" Light="#EDF2F7" Dark="#2D2D2D"/>
         </ResourceDictionary>
     </ContentPage.Resources>
 

--- a/ParacetamolPage.xaml
+++ b/ParacetamolPage.xaml
@@ -15,17 +15,22 @@
                 <ResourceDictionary Source="Resources/Styles/ModernStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <!-- Fond général de la page -->
-            <Color x:Key="MainBgColor">#F0F4F8</Color>
+            <AppThemeColor x:Key="MainBgColor" Light="#F0F4F8" Dark="#1F1F1F"/>
+            <AppThemeColor x:Key="EntryBgColor" Light="#EBF8FF" Dark="#3A3A3A"/>
+            <AppThemeColor x:Key="ChartSectionBgColor" Light="#E6FFFA" Dark="#2D2D2D"/>
+            <AppThemeColor x:Key="ListSectionBgColor" Light="#FFFDE7" Dark="#2D2D2D"/>
+            <AppThemeColor x:Key="ItemFrameBgColor" Light="#FAF5FF" Dark="#3A3A3A"/>
+            <AppThemeColor x:Key="ExportSectionBgColor" Light="#EDF2F7" Dark="#2D2D2D"/>
         </ResourceDictionary>
     </ContentPage.Resources>
 
     <ContentPage.Background>
-        <SolidColorBrush Color="{StaticResource MainBgColor}"/>
+        <SolidColorBrush Color="{DynamicResource MainBgColor}"/>
     </ContentPage.Background>
 
     <ScrollView>
         <VerticalStackLayout Style="{StaticResource PageRootLayoutStyle}"
-                             BackgroundColor="{StaticResource MainBgColor}">
+                             BackgroundColor="{DynamicResource MainBgColor}">
 
             <!-- AJOUTER UNE DOSE -->
             <Frame Style="{StaticResource CardFrameStyle}"
@@ -47,7 +52,7 @@
                                Grid.Column="1"
                                CornerRadius="8"
                                Padding="0"
-                               BackgroundColor="#EBF8FF"
+                               BackgroundColor="{DynamicResource EntryBgColor}"
                                HasShadow="False"
                                VerticalOptions="Center"
                                HeightRequest="32">
@@ -79,7 +84,7 @@
 
             <!-- CONCENTRATION & GRAPHIQUE -->
             <Frame Style="{StaticResource CardFrameStyle}"
-                   BackgroundColor="#E6FFFA">
+                   BackgroundColor="{DynamicResource ChartSectionBgColor}">
                 <VerticalStackLayout Spacing="8">
                     <Label Text="Concentration actuelle"
                            FontSize="20"
@@ -96,7 +101,7 @@
                            HorizontalOptions="Center"/>
                     <Frame Padding="10"
                            CornerRadius="10"
-                           BackgroundColor="White"
+                           Style="{StaticResource CardFrameStyle}"
                            HasShadow="True"
                            Margin="0,8,0,0"
                            HeightRequest="320">
@@ -190,7 +195,7 @@
 
             <!-- LISTE DES DOSES -->
             <Frame Style="{StaticResource CardFrameStyle}"
-                   BackgroundColor="#FFFDE7">
+                   BackgroundColor="{DynamicResource ListSectionBgColor}">
                 <VerticalStackLayout Spacing="8">
                     <Label Text="Doses récentes"
                            FontSize="20"
@@ -210,8 +215,8 @@
                                         IsVisible="True">
                             <CollectionView.ItemTemplate>
                                 <DataTemplate>
-                                    <Frame BackgroundColor="#FAF5FF"
-                                           CornerRadius="8"                                           
+                                    <Frame BackgroundColor="{DynamicResource ItemFrameBgColor}"
+                                           CornerRadius="8"
                                            Padding="10,6"
                                            Margin="0,3"
                                            HasShadow="False">
@@ -246,7 +251,7 @@
             <!-- BOUTONS EXPORT/RESET -->
             <Frame Style="{StaticResource CardFrameStyle}"
                    Padding="12"
-                   BackgroundColor="#EDF2F7">
+                   BackgroundColor="{DynamicResource ExportSectionBgColor}">
                 <HorizontalStackLayout Spacing="22"
                                        HorizontalOptions="Center">
                     <Button Text="💾 Exporter"

--- a/ParacetamolPage.xaml
+++ b/ParacetamolPage.xaml
@@ -15,12 +15,12 @@
                 <ResourceDictionary Source="Resources/Styles/ModernStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <!-- Fond général de la page -->
-            <AppThemeColor x:Key="MainBgColor" Light="#F0F4F8" Dark="#1F1F1F"/>
-            <AppThemeColor x:Key="EntryBgColor" Light="#EBF8FF" Dark="#3A3A3A"/>
-            <AppThemeColor x:Key="ChartSectionBgColor" Light="#E6FFFA" Dark="#2D2D2D"/>
-            <AppThemeColor x:Key="ListSectionBgColor" Light="#FFFDE7" Dark="#2D2D2D"/>
-            <AppThemeColor x:Key="ItemFrameBgColor" Light="#FAF5FF" Dark="#3A3A3A"/>
-            <AppThemeColor x:Key="ExportSectionBgColor" Light="#EDF2F7" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="MainBgColor" x:TypeArguments="Color" Light="#F0F4F8" Dark="#1F1F1F"/>
+            <OnAppTheme x:Key="EntryBgColor" x:TypeArguments="Color" Light="#EBF8FF" Dark="#3A3A3A"/>
+            <OnAppTheme x:Key="ChartSectionBgColor" x:TypeArguments="Color" Light="#E6FFFA" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="ListSectionBgColor" x:TypeArguments="Color" Light="#FFFDE7" Dark="#2D2D2D"/>
+            <OnAppTheme x:Key="ItemFrameBgColor" x:TypeArguments="Color" Light="#FAF5FF" Dark="#3A3A3A"/>
+            <OnAppTheme x:Key="ExportSectionBgColor" x:TypeArguments="Color" Light="#EDF2F7" Dark="#2D2D2D"/>
         </ResourceDictionary>
     </ContentPage.Resources>
 

--- a/Resources/Styles/ModernStyles.xaml
+++ b/Resources/Styles/ModernStyles.xaml
@@ -2,6 +2,13 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                     xmlns:chart="clr-namespace:Syncfusion.Maui.Charts;assembly=Syncfusion.Maui.Charts">
+    <!-- Background brushes used by the card style -->
+    <LinearGradientBrush x:Key="CardLightBackgroundBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="White" Offset="0"/>
+        <GradientStop Color="#F3F4F6" Offset="1"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="CardDarkBackgroundBrush" Color="#2D2D2D"/>
+
     <Style x:Key="CardFrameStyle" TargetType="Frame">
         <Setter Property="CornerRadius" Value="16"/>
         <Setter Property="Padding" Value="16"/>
@@ -12,10 +19,7 @@
             </Setter.Value>
         </Setter>
         <Setter Property="Background">
-            <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
-                <GradientStop Color="White" Offset="0"/>
-                <GradientStop Color="#F3F4F6" Offset="1"/>
-            </LinearGradientBrush>
+            <AppThemeBinding Light="{StaticResource CardLightBackgroundBrush}" Dark="{StaticResource CardDarkBackgroundBrush}"/>
         </Setter>
     </Style>
 

--- a/SettingsPage.xaml
+++ b/SettingsPage.xaml
@@ -8,11 +8,11 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Styles/ModernStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            <Color x:Key="MainBgColor">#F0F4F8</Color>
+            <AppThemeColor x:Key="MainBgColor" Light="#F0F4F8" Dark="#1F1F1F"/>
         </ResourceDictionary>
     </ContentPage.Resources>
     <ContentPage.Background>
-        <SolidColorBrush Color="{StaticResource MainBgColor}"/>
+        <SolidColorBrush Color="{DynamicResource MainBgColor}"/>
     </ContentPage.Background>
     <VerticalStackLayout Spacing="20" Padding="20">
         <Label Text="Poids (kg)" FontAttributes="Bold" />

--- a/SettingsPage.xaml
+++ b/SettingsPage.xaml
@@ -8,7 +8,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Styles/ModernStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            <AppThemeColor x:Key="MainBgColor" Light="#F0F4F8" Dark="#1F1F1F"/>
+            <OnAppTheme x:Key="MainBgColor" x:TypeArguments="Color" Light="#F0F4F8" Dark="#1F1F1F"/>
         </ResourceDictionary>
     </ContentPage.Resources>
     <ContentPage.Background>


### PR DESCRIPTION
## Summary
- add app theme colors for page elements
- update styles with card brushes for dark mode
- refactor pages to use dynamic theme colors

## Testing
- `dotnet build MoleculeEfficienceTracker.sln -v q` *(fails: NETSDK1178 missing workload packs)*

------
https://chatgpt.com/codex/tasks/task_e_6842089a64188330a65555277c441c11