### PR TITLE
Ajout courbe effet et modèle pharmacodynamique

### DIFF
--- a/BaseMoleculePage.cs
+++ b/BaseMoleculePage.cs
@@ -208,6 +208,15 @@ namespace MoleculeEfficienceTracker
             // Par défaut, ne fait rien. La page Caféine surchargera ceci.
         }
 
+        /// <summary>
+        /// Permet aux pages dérivées de calculer un pourcentage d'effet pour une concentration donnée.
+        /// Retourne null si aucun calcul n'est souhaité.
+        /// </summary>
+        protected virtual double? GetEffectPercentForConcentration(double concentration)
+        {
+            return null;
+        }
+
         protected async Task UpdateChart()
         {
             ChartData.Clear();
@@ -243,7 +252,9 @@ namespace MoleculeEfficienceTracker
 
             foreach ((DateTime Time, double Concentration) point in graphPoints)
             {
-                ChartData.Add(new ChartDataPoint(point.Time, point.Concentration));
+                double? effect = GetEffectPercentForConcentration(point.Concentration);
+                double effectValue = effect ?? 0;
+                ChartData.Add(new ChartDataPoint(point.Time, point.Concentration, effectValue));
             }
 
             if (chart.XAxes?.FirstOrDefault() is DateTimeAxis xAxis)

--- a/BromazepamPage.xaml
+++ b/BromazepamPage.xaml
@@ -145,7 +145,7 @@
                                 </chart:DateTimeAxis>
                             </chart:SfCartesianChart.XAxes>
                             <chart:SfCartesianChart.YAxes>
-                                <chart:NumericalAxis x:Name="ConcentrationAxis" Minimum="0"
+                                <chart:NumericalAxis x:Name="ConcentrationAxis" Minimum="0" Maximum="0.21"
                                                      ShowMajorGridLines="True"
                                                      ShowMinorGridLines="False">
                                     <chart:NumericalAxis.LabelStyle>
@@ -157,7 +157,7 @@
                                                 StrokeWidth="1"/>
                                     </chart:NumericalAxis.MajorGridLineStyle>
                                 </chart:NumericalAxis>
-                                <chart:NumericalAxis x:Name="EffectAxis" Minimum="0" Maximum="100" IsOpposed="True"
+                                <chart:NumericalAxis x:Name="EffectAxis" Minimum="0" Maximum="100" OpposedPosition="True"
                                                      ShowMajorGridLines="False">
                                     <chart:NumericalAxis.LabelStyle>
                                         <chart:ChartAxisLabelStyle FontSize="10" TextColor="#9B2C2C"/>
@@ -170,6 +170,7 @@
                                 ItemsSource="{Binding ChartData}"
                                 XBindingPath="Time"
                                 YBindingPath="Concentration"
+                                YAxisName="ConcentrationAxis"
                                 Fill="Blue"
                                 StrokeWidth="1.5"
                                 EnableTooltip="True"

--- a/BromazepamPage.xaml
+++ b/BromazepamPage.xaml
@@ -90,9 +90,13 @@
                            FontAttributes="Bold"
                            TextColor="#22543D"
                            HorizontalOptions="Center"/>
-                    <Label x:Name="LastUpdateLabel"
+                   <Label x:Name="LastUpdateLabel"
                            FontSize="14"
                            TextColor="#718096"
+                           HorizontalOptions="Center"/>
+                    <Label x:Name="EffectPower"
+                           FontSize="14"
+                           TextColor="#22543D"
                            HorizontalOptions="Center"/>
                     <Label x:Name="EffectStatus"
                            FontSize="14"
@@ -141,7 +145,7 @@
                                 </chart:DateTimeAxis>
                             </chart:SfCartesianChart.XAxes>
                             <chart:SfCartesianChart.YAxes>
-                                <chart:NumericalAxis Minimum="0"
+                                <chart:NumericalAxis x:Name="ConcentrationAxis" Minimum="0"
                                                      ShowMajorGridLines="True"
                                                      ShowMinorGridLines="False">
                                     <chart:NumericalAxis.LabelStyle>
@@ -152,6 +156,12 @@
                                         <chart:ChartLineStyle Stroke="#E5E7EB"
                                                 StrokeWidth="1"/>
                                     </chart:NumericalAxis.MajorGridLineStyle>
+                                </chart:NumericalAxis>
+                                <chart:NumericalAxis x:Name="EffectAxis" Minimum="0" Maximum="100" OpposedPosition="True"
+                                                     ShowMajorGridLines="False">
+                                    <chart:NumericalAxis.LabelStyle>
+                                        <chart:ChartAxisLabelStyle FontSize="10" TextColor="#9B2C2C"/>
+                                    </chart:NumericalAxis.LabelStyle>
                                 </chart:NumericalAxis>
                             </chart:SfCartesianChart.YAxes>
 
@@ -184,6 +194,34 @@
                                                        TextColor="White"
                                                        FontSize="12"/>
                                                 <Label Text="{Binding Item.Concentration, StringFormat='📈 {0:F2} mg'}"
+                                                       TextColor="White"
+                                                       FontSize="13"
+                                                       FontAttributes="Bold"/>
+                                            </VerticalStackLayout>
+                                        </Border>
+                                    </DataTemplate>
+                                </chart:SplineSeries.TooltipTemplate>
+                            </chart:SplineSeries>
+                            <chart:SplineSeries
+                                ItemsSource="{Binding ChartData}"
+                                XBindingPath="Time"
+                                YBindingPath="EffectPercent"
+                                YAxisName="EffectAxis"
+                                Stroke="DarkOrange"
+                                StrokeWidth="1.5"
+                                EnableTooltip="True"
+                                ShowMarkers="False">
+                                <chart:SplineSeries.TooltipTemplate>
+                                    <DataTemplate>
+                                        <Border Background="#23272F"
+                                                Padding="7"
+                                                Stroke="White"
+                                                StrokeThickness="0.5">
+                                            <VerticalStackLayout>
+                                                <Label Text="{Binding Item.Time, StringFormat='🕒 {0:dd/MM HH:mm}'}"
+                                                       TextColor="White"
+                                                       FontSize="12"/>
+                                                <Label Text="{Binding Item.EffectPercent, StringFormat='⚡ {0:F0}%'}"
                                                        TextColor="White"
                                                        FontSize="13"
                                                        FontAttributes="Bold"/>

--- a/BromazepamPage.xaml
+++ b/BromazepamPage.xaml
@@ -157,7 +157,7 @@
                                                 StrokeWidth="1"/>
                                     </chart:NumericalAxis.MajorGridLineStyle>
                                 </chart:NumericalAxis>
-                                <chart:NumericalAxis x:Name="EffectAxis" Minimum="0" Maximum="100" OpposedPosition="True"
+                                <chart:NumericalAxis x:Name="EffectAxis" Minimum="0" Maximum="100" IsOpposed="True"
                                                      ShowMajorGridLines="False">
                                     <chart:NumericalAxis.LabelStyle>
                                         <chart:ChartAxisLabelStyle FontSize="10" TextColor="#9B2C2C"/>

--- a/BromazepamPage.xaml
+++ b/BromazepamPage.xaml
@@ -145,7 +145,7 @@
                                 </chart:DateTimeAxis>
                             </chart:SfCartesianChart.XAxes>
                             <chart:SfCartesianChart.YAxes>
-                                <chart:NumericalAxis x:Name="ConcentrationAxis" Minimum="0" Maximum="0.21"
+                                <chart:NumericalAxis x:Name="ConcentrationAxis" Name="ConcentrationAxis" Minimum="0" Maximum="0.21"
                                                      ShowMajorGridLines="True"
                                                      ShowMinorGridLines="False">
                                     <chart:NumericalAxis.LabelStyle>
@@ -157,7 +157,7 @@
                                                 StrokeWidth="1"/>
                                     </chart:NumericalAxis.MajorGridLineStyle>
                                 </chart:NumericalAxis>
-                                <chart:NumericalAxis x:Name="EffectAxis" Minimum="0" Maximum="100" OpposedPosition="True"
+                                <chart:NumericalAxis x:Name="EffectAxis" Name="EffectAxis" Minimum="0" Maximum="100" OpposedPosition="True"
                                                      ShowMajorGridLines="False">
                                     <chart:NumericalAxis.LabelStyle>
                                         <chart:ChartAxisLabelStyle FontSize="10" TextColor="#9B2C2C"/>

--- a/BromazepamPage.xaml.cs
+++ b/BromazepamPage.xaml.cs
@@ -25,6 +25,9 @@ namespace MoleculeEfficienceTracker
         // Labels spécifiques à l'effet
         private Label EffectStatusLabel => EffectStatus;
         private Label EffectEndPredictionLabel => EffectPrediction;
+        private Label EffectPowerLabel => EffectPower;
+
+        private readonly PharmacodynamicModel _pdModel = new PharmacodynamicModel(0.05);
         
 
         protected override string DoseAnnotationIcon => "💊";
@@ -46,6 +49,7 @@ namespace MoleculeEfficienceTracker
             if (Calculator is BromazepamCalculator calc)
             {
                 double concentration = calc.CalculateTotalConcentration(doses, currentTime);
+                double effectPercent = _pdModel.GetEffectPercent(concentration);
                 var level = calc.GetEffectLevel(concentration);
 
                 string text = level switch
@@ -69,6 +73,12 @@ namespace MoleculeEfficienceTracker
                     EffectStatusLabel.Text = text;
                     EffectStatusLabel.TextColor = color;
                     EffectStatusLabel.IsVisible = true;
+                }
+
+                if (EffectPowerLabel != null)
+                {
+                    EffectPowerLabel.Text = $"Puissance de l'effet : {effectPercent:F0} %";
+                    EffectPowerLabel.IsVisible = true;
                 }
 
                 DateTime? endTime = calc.PredictEffectEndTime(doses, currentTime);
@@ -121,6 +131,11 @@ namespace MoleculeEfficienceTracker
                 AddThresholdAnnotation(BromazepamCalculator.LIGHT_THRESHOLD, "Effet léger", Colors.Orange);
                 AddThresholdAnnotation(BromazepamCalculator.NEGLIGIBLE_THRESHOLD, "Seuil de perception", Colors.Red);
             }
+        }
+
+        protected override double? GetEffectPercentForConcentration(double concentration)
+        {
+            return _pdModel.GetEffectPercent(concentration);
         }
 
         protected override async Task OnBeforeLoadDataAsync()

--- a/Core/Models/ChartDataPoint.cs
+++ b/Core/Models/ChartDataPoint.cs
@@ -4,11 +4,13 @@ public class ChartDataPoint
 {
     public DateTime Time { get; set; }
     public double Concentration { get; set; }
+    public double EffectPercent { get; set; }
 
-    public ChartDataPoint(DateTime time, double concentration)
+    public ChartDataPoint(DateTime time, double concentration, double effectPercent = 0)
     {
         Time = time;
         Concentration = concentration;
+        EffectPercent = effectPercent;
     }
 }
 

--- a/Core/Services/PharmacodynamicModel.cs
+++ b/Core/Services/PharmacodynamicModel.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace MoleculeEfficienceTracker.Core.Services
+{
+    /// <summary>
+    /// Modèle pharmacodynamique simple de type Emax (coefficient de Hill n = 1).
+    /// Relie la concentration en mg/L à un effet relatif exprimé en pourcentage.
+    /// </summary>
+    public class PharmacodynamicModel
+    {
+        /// <summary>
+        /// Effet maximal en pourcentage (par exemple 100 = effet maximal).
+        /// </summary>
+        public const double E_MAX_PERCENT = 100.0;
+
+        /// <summary>
+        /// Concentration pour 50 % d'effet (EC50).
+        /// </summary>
+        public readonly double EC50;
+
+        /// <summary>
+        /// Initialise un nouveau modèle avec une valeur EC50 spécifique.
+        /// </summary>
+        /// <param name="ec50">Concentration en mg/L donnant 50 % d'effet.</param>
+        public PharmacodynamicModel(double ec50)
+        {
+            EC50 = ec50;
+        }
+
+        /// <summary>
+        /// Retourne l'effet en pourcentage pour la concentration donnée.
+        /// </summary>
+        /// <param name="concentrationMgPerL">Concentration plasmatique mg/L.</param>
+        public double GetEffectPercent(double concentrationMgPerL)
+        {
+            if (concentrationMgPerL <= 0)
+                return 0.0;
+
+            double ratio = concentrationMgPerL / (concentrationMgPerL + EC50);
+            return E_MAX_PERCENT * ratio;
+        }
+
+        /// <summary>
+        /// Variante retournant l'effet sous forme fractionnaire (0 à 1).
+        /// </summary>
+        public double GetEffectFraction(double concentrationMgPerL)
+        {
+            if (concentrationMgPerL <= 0)
+                return 0.0;
+
+            return concentrationMgPerL / (concentrationMgPerL + EC50);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `PharmacodynamicModel` for Emax relation
- enrich `ChartDataPoint` with `EffectPercent`
- allow pages to provide effect percent through `GetEffectPercentForConcentration`
- display effect power and additional effect curve on Bromazepam page

## Testing
- `dotnet build --no-restore` *(fails: missing MAUI workloads)*

------
https://chatgpt.com/codex/tasks/task_e_684294ee63ac833089b8d0c3a61bff7d