### PR TITLE
Réduit la plage de zoom initiale du paracétamol

### DIFF
--- a/ParacetamolPage.xaml.cs
+++ b/ParacetamolPage.xaml.cs
@@ -27,8 +27,10 @@ namespace MoleculeEfficienceTracker
         protected override TimeSpan GraphDataStartOffset => TimeSpan.FromDays(-7);
         protected override TimeSpan GraphDataEndOffset => TimeSpan.FromDays(3);
         protected override int GraphDataNumberOfPoints => 10 * 24 * 2;
-        protected override TimeSpan InitialVisibleStartOffset => TimeSpan.FromHours(-12); // Ajustez si nécessaire
-        protected override TimeSpan InitialVisibleEndOffset => TimeSpan.FromHours(24);  // Ajustez si nécessaire
+        // Zoom plus serré : la majorité des utilisations concernent un seul
+        // comprimé de 1 g, l'effet durant seulement quelques heures.
+        protected override TimeSpan InitialVisibleStartOffset => TimeSpan.FromHours(-4);
+        protected override TimeSpan InitialVisibleEndOffset => TimeSpan.FromHours(12);
 
 
         public ParacetamolPage() : base("paracetamol")


### PR DESCRIPTION
## Summary
- ajuste la vue par défaut du graphique Paracétamol pour afficher une plage plus courte

## Testing
- `dotnet build -c Release` *(échoue: workloads manquants)*

------
https://chatgpt.com/codex/tasks/task_e_684340cf788c8330b6244f4d70a3ebbe