### PR TITLE
Add paracetamol effect curve

### DIFF
--- a/Core/Services/ParacetamolCalculator.cs
+++ b/Core/Services/ParacetamolCalculator.cs
@@ -16,6 +16,12 @@ namespace MoleculeEfficienceTracker.Core.Services
         private const double BIOAVAILABILITY = 0.92; // Fraction absorbée
         private const double VOLUME_DISTRIBUTION_L_PER_KG = 0.95; // Volume de distribution
 
+        // Seuils d'effet exprimés en mg/L
+        public const double STRONG_THRESHOLD = 25.0;      // mg/L : effet fort, pic après 1g
+        public const double MODERATE_THRESHOLD = 12.0;    // mg/L : effet net
+        public const double LIGHT_THRESHOLD = 5.0;        // mg/L : effet léger
+        public const double NEGLIGIBLE_THRESHOLD = 2.0;   // mg/L : effet négligeable
+
         private readonly double eliminationConstant; // ke
         private readonly double absorptionConstant; // ka
 
@@ -74,5 +80,33 @@ namespace MoleculeEfficienceTracker.Core.Services
 
             return points;
         }
+
+        // Détermine le niveau d'effet subjectif en fonction de la concentration
+        public EffectLevel GetEffectLevel(double concentration)
+        {
+            if (concentration >= STRONG_THRESHOLD) return EffectLevel.Strong;
+            if (concentration >= MODERATE_THRESHOLD) return EffectLevel.Moderate;
+            if (concentration >= LIGHT_THRESHOLD) return EffectLevel.Light;
+            return EffectLevel.None;
+        }
+
+        // Estime quand la concentration passera sous le seuil négligeable
+        public DateTime? PredictEffectEndTime(List<DoseEntry> doses, DateTime currentTime)
+        {
+            if (!doses.Any()) return currentTime;
+
+            for (int minutes = 0; minutes <= 24 * 60; minutes += 15)
+            {
+                DateTime checkTime = currentTime.AddMinutes(minutes);
+                double conc = CalculateTotalConcentration(doses, checkTime);
+                if (conc < NEGLIGIBLE_THRESHOLD)
+                    return checkTime;
+            }
+
+            return null;
+        }
+
+        // Indique si l'effet est négligeable pour une concentration donnée
+        public bool IsEffectNegligible(double concentration) => concentration < NEGLIGIBLE_THRESHOLD;
     }
 }

--- a/ParacetamolPage.xaml
+++ b/ParacetamolPage.xaml
@@ -90,10 +90,24 @@
                            FontAttributes="Bold"
                            TextColor="#22543D"
                            HorizontalOptions="Center"/>
-                    <Label x:Name="LastUpdateLabel"
+                   <Label x:Name="LastUpdateLabel"
+                          FontSize="14"
+                          TextColor="#718096"
+                          HorizontalOptions="Center"/>
+                    <Label x:Name="EffectPower"
                            FontSize="14"
-                           TextColor="#718096"
+                           TextColor="#22543D"
                            HorizontalOptions="Center"/>
+                    <Label x:Name="EffectStatus"
+                           FontSize="14"
+                           HorizontalOptions="Center"
+                           TextColor="Green"
+                           Text=""/>
+                    <Label x:Name="EffectPrediction"
+                           FontSize="12"
+                           HorizontalOptions="Center"
+                           TextColor="Red"
+                           Text=""/>
                     <Frame Padding="10"
                            CornerRadius="10"
                            BackgroundColor="White"
@@ -131,7 +145,7 @@
                                 </chart:DateTimeAxis>
                             </chart:SfCartesianChart.XAxes>
                             <chart:SfCartesianChart.YAxes>
-                                <chart:NumericalAxis Minimum="0"
+                                <chart:NumericalAxis x:Name="ConcentrationAxis" Name="ConcentrationAxis" Minimum="0"
                                                      ShowMajorGridLines="True"
                                                      ShowMinorGridLines="False">
                                     <chart:NumericalAxis.LabelStyle>
@@ -143,6 +157,12 @@
                                                 StrokeWidth="1"/>
                                     </chart:NumericalAxis.MajorGridLineStyle>
                                 </chart:NumericalAxis>
+                                <chart:NumericalAxis x:Name="EffectAxis" Name="EffectAxis" Minimum="0" Maximum="100"
+                                                     ShowMajorGridLines="False">
+                                    <chart:NumericalAxis.LabelStyle>
+                                        <chart:ChartAxisLabelStyle FontSize="10" TextColor="#9B2C2C"/>
+                                    </chart:NumericalAxis.LabelStyle>
+                                </chart:NumericalAxis>
                             </chart:SfCartesianChart.YAxes>
 
                             <!-- COURBE LISSEE et POINTS NOIRS -->
@@ -150,6 +170,7 @@
                                 ItemsSource="{Binding ChartData}"
                                 XBindingPath="Time"
                                 YBindingPath="Concentration"
+                                YAxisName="ConcentrationAxis"
                                 Fill="Blue"
                                 StrokeWidth="1.5"
                                 EnableTooltip="True"
@@ -174,6 +195,33 @@
                                                        TextColor="White"
                                                        FontSize="12"/>
                                                 <Label Text="{Binding Item.Concentration, StringFormat='📈 {0:F2} mg'}"
+                                                       TextColor="White"
+                                                       FontSize="13"
+                                                       FontAttributes="Bold"/>
+                                            </VerticalStackLayout>
+                                        </Border>
+                                    </DataTemplate>
+                                </chart:SplineSeries.TooltipTemplate>
+                            </chart:SplineSeries>
+                            <chart:SplineSeries
+                                ItemsSource="{Binding ChartData}"
+                                XBindingPath="Time"
+                                YBindingPath="EffectPercent"
+                                YAxisName="EffectAxis"
+                                StrokeWidth="1.5"
+                                EnableTooltip="True"
+                                ShowMarkers="False">
+                                <chart:SplineSeries.TooltipTemplate>
+                                    <DataTemplate>
+                                        <Border Background="#23272F"
+                                                Padding="7"
+                                                Stroke="White"
+                                                StrokeThickness="0.5">
+                                            <VerticalStackLayout>
+                                                <Label Text="{Binding Item.Time, StringFormat='🕒 {0:dd/MM HH:mm}'}"
+                                                       TextColor="White"
+                                                       FontSize="12"/>
+                                                <Label Text="{Binding Item.EffectPercent, StringFormat='⚡ {0:F0}%'}"
                                                        TextColor="White"
                                                        FontSize="13"
                                                        FontAttributes="Bold"/>

--- a/ParacetamolPage.xaml.cs
+++ b/ParacetamolPage.xaml.cs
@@ -21,6 +21,13 @@ namespace MoleculeEfficienceTracker
         protected override SfCartesianChart ChartControl => ConcentrationChart;
         protected override CollectionView DosesDisplayCollection => DosesCollection;
         protected override Label EmptyStateIndicatorLabel => EmptyDosesLabel;
+
+        // Labels spécifiques à l'effet
+        private Label EffectStatusLabel => EffectStatus;
+        private Label EffectEndPredictionLabel => EffectPrediction;
+        private Label EffectPowerLabel => EffectPower;
+
+        private readonly PharmacodynamicModel _pdModel = new PharmacodynamicModel(ParacetamolCalculator.STRONG_THRESHOLD);
         
 
         protected override string DoseAnnotationIcon => "💊";
@@ -42,6 +49,104 @@ namespace MoleculeEfficienceTracker
         protected override async Task OnBeforeLoadDataAsync()
         {
             await base.OnBeforeLoadDataAsync(); // Appel à l'implémentation de base (facultatif ici car vide)
+        }
+
+        protected override void UpdateMoleculeSpecificConcentrationInfo(List<DoseEntry> doses, DateTime currentTime)
+        {
+            if (Calculator is ParacetamolCalculator calc)
+            {
+                double concentration = calc.CalculateTotalConcentration(doses, currentTime);
+                double totalMg = calc.CalculateTotalAmount(doses, currentTime);
+
+                ConcentrationOutputLabel.Text = $"{totalMg:F0} mg ({concentration:F2} {Calculator.ConcentrationUnit})";
+
+                double effectPercent = _pdModel.GetEffectPercent(concentration);
+                var level = calc.GetEffectLevel(concentration);
+
+                string text = level switch
+                {
+                    EffectLevel.Strong => "Effet fort",
+                    EffectLevel.Moderate => "Effet modéré",
+                    EffectLevel.Light => "Effet léger",
+                    _ => "Effet négligeable"
+                };
+
+                Color color = level switch
+                {
+                    EffectLevel.Strong => Colors.Red,
+                    EffectLevel.Moderate => Colors.Green,
+                    EffectLevel.Light => Colors.Green,
+                    _ => Colors.Gray
+                };
+
+                if (EffectStatusLabel != null)
+                {
+                    EffectStatusLabel.Text = text;
+                    EffectStatusLabel.TextColor = color;
+                    EffectStatusLabel.IsVisible = true;
+                }
+
+                if (EffectPowerLabel != null)
+                {
+                    EffectPowerLabel.Text = $"Estimation d'efficacité : {effectPercent:F0} %";
+                    EffectPowerLabel.IsVisible = true;
+                }
+
+                DateTime? endTime = calc.PredictEffectEndTime(doses, currentTime);
+                if (EffectEndPredictionLabel != null)
+                {
+                    if (endTime.HasValue && endTime.Value > currentTime)
+                    {
+                        var remaining = endTime.Value - currentTime;
+                        EffectEndPredictionLabel.Text = $"Effet négligeable estimé dans {remaining.TotalHours:F1} heures";
+                    }
+                    else
+                    {
+                        EffectEndPredictionLabel.Text = "Effet actuellement négligeable";
+                    }
+                    EffectEndPredictionLabel.IsVisible = true;
+                }
+            }
+        }
+
+        private void AddThresholdAnnotation(double yValue, string text, Color color)
+        {
+            var annotation = new HorizontalLineAnnotation
+            {
+                Y1 = yValue,
+                Stroke = new SolidColorBrush(color),
+                StrokeWidth = 2,
+                StrokeDashArray = new DoubleCollection { 5, 5 },
+                Text = text,
+                LabelStyle = new ChartAnnotationLabelStyle
+                {
+                    FontSize = 10,
+                    TextColor = color,
+                    Background = Brush.White,
+                    CornerRadius = 3,
+                    HorizontalTextAlignment = ChartLabelAlignment.Start,
+                    VerticalTextAlignment = ChartLabelAlignment.Center,
+                    Margin = new Thickness(5, 0, 0, 0)
+                }
+            };
+
+            ChartControl.Annotations.Add(annotation);
+        }
+
+        protected override void AddMoleculeSpecificChartAnnotations()
+        {
+            if (Calculator is ParacetamolCalculator calc && ChartControl != null)
+            {
+                AddThresholdAnnotation(ParacetamolCalculator.STRONG_THRESHOLD, "Fort (1g)", Colors.Orange);
+                AddThresholdAnnotation(ParacetamolCalculator.MODERATE_THRESHOLD, "Modéré", Colors.YellowGreen);
+                AddThresholdAnnotation(ParacetamolCalculator.LIGHT_THRESHOLD, "Léger", Colors.Green);
+                AddThresholdAnnotation(ParacetamolCalculator.NEGLIGIBLE_THRESHOLD, "Imperceptible", Colors.Grey);
+            }
+        }
+
+        protected override double? GetEffectPercentForConcentration(double concentration)
+        {
+            return _pdModel.GetEffectPercent(concentration);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add pharmacodynamic thresholds in `ParacetamolCalculator`
- compute effect level and predictions for paracetamol
- display effect axis and curve in paracetamol page
- show effect labels and threshold annotations

## Testing
- `dotnet restore` *(fails: workloads missing)*
- `dotnet build --no-restore` *(fails: workloads missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844bebe36688330a5b3a5d06df6257f