### PR TITLE
Add ibuprofen effect curve with thresholds

### DIFF
--- a/IbuprofenePage.xaml
+++ b/IbuprofenePage.xaml
@@ -90,10 +90,24 @@
                            FontAttributes="Bold"
                            TextColor="#22543D"
                            HorizontalOptions="Center"/>
-                    <Label x:Name="LastUpdateLabel"
+                   <Label x:Name="LastUpdateLabel"
                            FontSize="14"
                            TextColor="#718096"
                            HorizontalOptions="Center"/>
+                    <Label x:Name="EffectPower"
+                           FontSize="14"
+                           TextColor="#22543D"
+                           HorizontalOptions="Center"/>
+                    <Label x:Name="EffectStatus"
+                           FontSize="14"
+                           HorizontalOptions="Center"
+                           TextColor="Green"
+                           Text=""/>
+                    <Label x:Name="EffectPrediction"
+                           FontSize="12"
+                           HorizontalOptions="Center"
+                           TextColor="Red"
+                           Text=""/>
                     <Frame Padding="10"
                            CornerRadius="10"
                            BackgroundColor="White"
@@ -131,17 +145,21 @@
                                 </chart:DateTimeAxis>
                             </chart:SfCartesianChart.XAxes>
                             <chart:SfCartesianChart.YAxes>
-                                <chart:NumericalAxis Minimum="0"
+                                <chart:NumericalAxis x:Name="ConcentrationAxis" Name="ConcentrationAxis" Minimum="0"
                                                      ShowMajorGridLines="True"
                                                      ShowMinorGridLines="False">
                                     <chart:NumericalAxis.LabelStyle>
-                                        <chart:ChartAxisLabelStyle FontSize="10"
-                                                                   TextColor="#31465D"/>
+                                        <chart:ChartAxisLabelStyle FontSize="10" TextColor="#31465D"/>
                                     </chart:NumericalAxis.LabelStyle>
                                     <chart:NumericalAxis.MajorGridLineStyle>
-                                        <chart:ChartLineStyle Stroke="#E5E7EB"
-                                                StrokeWidth="1"/>
+                                        <chart:ChartLineStyle Stroke="#E5E7EB" StrokeWidth="1"/>
                                     </chart:NumericalAxis.MajorGridLineStyle>
+                                </chart:NumericalAxis>
+                                <chart:NumericalAxis x:Name="EffectAxis" Name="EffectAxis" Minimum="0" Maximum="100"
+                                                     ShowMajorGridLines="False">
+                                    <chart:NumericalAxis.LabelStyle>
+                                        <chart:ChartAxisLabelStyle FontSize="10" TextColor="#9B2C2C"/>
+                                    </chart:NumericalAxis.LabelStyle>
                                 </chart:NumericalAxis>
                             </chart:SfCartesianChart.YAxes>
 
@@ -150,6 +168,7 @@
                                 ItemsSource="{Binding ChartData}"
                                 XBindingPath="Time"
                                 YBindingPath="Concentration"
+                                YAxisName="ConcentrationAxis"
                                 Fill="Blue"
                                 StrokeWidth="1.5"
                                 EnableTooltip="True"
@@ -174,6 +193,33 @@
                                                        TextColor="White"
                                                        FontSize="12"/>
                                                 <Label Text="{Binding Item.Concentration, StringFormat='📈 {0:F2} mg'}"
+                                                       TextColor="White"
+                                                       FontSize="13"
+                                                       FontAttributes="Bold"/>
+                                            </VerticalStackLayout>
+                                        </Border>
+                                    </DataTemplate>
+                                </chart:SplineSeries.TooltipTemplate>
+                            </chart:SplineSeries>
+                            <chart:SplineSeries
+                                ItemsSource="{Binding ChartData}"
+                                XBindingPath="Time"
+                                YBindingPath="EffectPercent"
+                                YAxisName="EffectAxis"
+                                StrokeWidth="1.5"
+                                EnableTooltip="True"
+                                ShowMarkers="False">
+                                <chart:SplineSeries.TooltipTemplate>
+                                    <DataTemplate>
+                                        <Border Background="#23272F"
+                                                Padding="7"
+                                                Stroke="White"
+                                                StrokeThickness="0.5">
+                                            <VerticalStackLayout>
+                                                <Label Text="{Binding Item.Time, StringFormat='🕒 {0:dd/MM HH:mm}'}"
+                                                       TextColor="White"
+                                                       FontSize="12"/>
+                                                <Label Text="{Binding Item.EffectPercent, StringFormat='⚡ {0:F0}%'}"
                                                        TextColor="White"
                                                        FontSize="13"
                                                        FontAttributes="Bold"/>

--- a/IbuprofenePage.xaml.cs
+++ b/IbuprofenePage.xaml.cs
@@ -21,7 +21,13 @@ namespace MoleculeEfficienceTracker
         protected override SfCartesianChart ChartControl => ConcentrationChart;
         protected override CollectionView DosesDisplayCollection => DosesCollection;
         protected override Label EmptyStateIndicatorLabel => EmptyDosesLabel;
-        
+
+        // Labels spécifiques à l'effet
+        private Label EffectStatusLabel => EffectStatus;
+        private Label EffectEndPredictionLabel => EffectPrediction;
+        private Label EffectPowerLabel => EffectPower;
+
+        private readonly PharmacodynamicModel _pdModel = new PharmacodynamicModel(12.0);
 
         protected override string DoseAnnotationIcon => "💊";
         protected override TimeSpan GraphDataStartOffset => TimeSpan.FromDays(-7);
@@ -37,9 +43,103 @@ namespace MoleculeEfficienceTracker
             base.InitializePageUI();
         }
 
+        protected override void UpdateMoleculeSpecificConcentrationInfo(List<DoseEntry> doses, DateTime currentTime)
+        {
+            if (Calculator is IbuprofeneCalculator calc)
+            {
+                double concentration = calc.CalculateTotalConcentration(doses, currentTime);
+                double effectPercent = _pdModel.GetEffectPercent(concentration);
+                var level = calc.GetEffectLevel(concentration);
+
+                string text = level switch
+                {
+                    EffectLevel.Strong => "Effet fort",
+                    EffectLevel.Moderate => "Effet modéré",
+                    EffectLevel.Light => "Effet léger",
+                    _ => "Effet négligeable"
+                };
+
+                Color color = level switch
+                {
+                    EffectLevel.Strong => Colors.Red,
+                    EffectLevel.Moderate => Colors.Green,
+                    EffectLevel.Light => Colors.Orange,
+                    _ => Colors.Gray
+                };
+
+                if (EffectStatusLabel != null)
+                {
+                    EffectStatusLabel.Text = text;
+                    EffectStatusLabel.TextColor = color;
+                    EffectStatusLabel.IsVisible = true;
+                }
+
+                if (EffectPowerLabel != null)
+                {
+                    EffectPowerLabel.Text = $"Effet estimé : {effectPercent:F0} %";
+                    EffectPowerLabel.IsVisible = true;
+                }
+
+                DateTime? endTime = calc.PredictEffectEndTime(doses, currentTime);
+                if (EffectEndPredictionLabel != null)
+                {
+                    if (endTime.HasValue && endTime.Value > currentTime)
+                    {
+                        var remaining = endTime.Value - currentTime;
+                        EffectEndPredictionLabel.Text = $"Effet négligeable dans {remaining.TotalHours:F1} h";
+                    }
+                    else
+                    {
+                        EffectEndPredictionLabel.Text = "Effet actuellement négligeable";
+                    }
+                    EffectEndPredictionLabel.IsVisible = true;
+                }
+            }
+        }
+
         protected override async Task OnBeforeLoadDataAsync()
         {
             await base.OnBeforeLoadDataAsync(); // Appel à l'implémentation de base (facultatif ici car vide)
+        }
+
+        private void AddThresholdAnnotation(double yValue, string text, Color color)
+        {
+            var annotation = new HorizontalLineAnnotation
+            {
+                Y1 = yValue,
+                Stroke = new SolidColorBrush(color),
+                StrokeWidth = 2,
+                StrokeDashArray = new DoubleCollection { 5, 5 },
+                Text = text,
+                LabelStyle = new ChartAnnotationLabelStyle
+                {
+                    FontSize = 10,
+                    TextColor = color,
+                    Background = Brush.White,
+                    CornerRadius = 3,
+                    HorizontalTextAlignment = ChartLabelAlignment.Start,
+                    VerticalTextAlignment = ChartLabelAlignment.Center,
+                    Margin = new Thickness(5, 0, 0, 0)
+                }
+            };
+
+            ChartControl.Annotations.Add(annotation);
+        }
+
+        protected override void AddMoleculeSpecificChartAnnotations()
+        {
+            if (Calculator is IbuprofeneCalculator calc && ChartControl != null)
+            {
+                AddThresholdAnnotation(IbuprofeneCalculator.STRONG_THRESHOLD, "Fort", Colors.Orange);
+                AddThresholdAnnotation(IbuprofeneCalculator.MODERATE_THRESHOLD, "Modéré", Colors.YellowGreen);
+                AddThresholdAnnotation(IbuprofeneCalculator.LIGHT_THRESHOLD, "Léger", Colors.Green);
+                AddThresholdAnnotation(IbuprofeneCalculator.NEGLIGIBLE_THRESHOLD, "Imperceptible", Colors.Grey);
+            }
+        }
+
+        protected override double? GetEffectPercentForConcentration(double concentration)
+        {
+            return _pdModel.GetEffectPercent(concentration);
         }
     }
 }


### PR DESCRIPTION
## Summary
- define strong/moderate/light thresholds in `IbuprofeneCalculator`
- implement effect level evaluation methods
- display effect status and prediction on Ibuprofen page
- plot a second curve for effect percent with dedicated axis

## Testing
- `dotnet build` *(fails: workloads missing)*
- `dotnet format MoleculeEfficienceTracker.sln --verify-no-changes` *(fails: restore operation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68469f3b62f08330991d81582fbaafc2