### PR TITLE
Improve chart performance

### DIFF
--- a/Core/Services/AlcoholCalculator.cs
+++ b/Core/Services/AlcoholCalculator.cs
@@ -102,11 +102,25 @@ namespace MoleculeEfficienceTracker.Core.Services
             var timeSpan = endTime - startTime;
             var interval = timeSpan.TotalMinutes / pointCount;
 
+            var doseParams = doses.Select(d => new
+            {
+                d.TimeTaken,
+                A = (d.DoseMg * absorptionConstant) /
+                    (absorptionConstant - eliminationConstant)
+            }).ToList();
+
             for (int i = 0; i <= pointCount; i++)
             {
                 var currentTime = startTime.AddMinutes(i * interval);
-                var concentration = CalculateTotalConcentration(doses, currentTime);
-                points.Add((currentTime, concentration));
+                double total = 0;
+                foreach (var p in doseParams)
+                {
+                    double hoursElapsed = (currentTime - p.TimeTaken).TotalHours;
+                    if (hoursElapsed < 0) continue;
+                    double conc = p.A * (Math.Exp(-eliminationConstant * hoursElapsed) - Math.Exp(-absorptionConstant * hoursElapsed));
+                    if (conc > 0) total += conc;
+                }
+                points.Add((currentTime, total));
             }
 
             return points;

--- a/Core/Services/BromazepamCalculator.cs
+++ b/Core/Services/BromazepamCalculator.cs
@@ -93,11 +93,25 @@ namespace MoleculeEfficienceTracker.Core.Services
             var timeSpan = endTime - startTime;
             var interval = timeSpan.TotalMinutes / pointCount;
 
+            var doseParams = doses.Select(d => new
+            {
+                d.TimeTaken,
+                A = (d.DoseMg * BIOAVAILABILITY * absorptionConstant) /
+                    (d.WeightKg * VOLUME_DISTRIBUTION_L_PER_KG * (absorptionConstant - eliminationConstant))
+            }).ToList();
+
             for (int i = 0; i <= pointCount; i++)
             {
                 var currentTime = startTime.AddMinutes(i * interval);
-                var concentration = CalculateTotalConcentration(doses, currentTime);
-                points.Add((currentTime, concentration));
+                double total = 0;
+                foreach (var p in doseParams)
+                {
+                    double hoursElapsed = (currentTime - p.TimeTaken).TotalHours;
+                    if (hoursElapsed < 0) continue;
+                    double conc = p.A * (Math.Exp(-eliminationConstant * hoursElapsed) - Math.Exp(-absorptionConstant * hoursElapsed));
+                    if (conc > 0) total += conc;
+                }
+                points.Add((currentTime, total));
             }
 
             return points;

--- a/Core/Services/IbuprofeneCalculator.cs
+++ b/Core/Services/IbuprofeneCalculator.cs
@@ -71,11 +71,25 @@ namespace MoleculeEfficienceTracker.Core.Services
             var timeSpan = endTime - startTime;
             var interval = timeSpan.TotalMinutes / pointCount;
 
+            var doseParams = doses.Select(d => new
+            {
+                d.TimeTaken,
+                A = (d.DoseMg * BIOAVAILABILITY * absorptionConstant) /
+                    (d.WeightKg * VOLUME_DISTRIBUTION_L_PER_KG * (absorptionConstant - eliminationConstant))
+            }).ToList();
+
             for (int i = 0; i <= pointCount; i++)
             {
                 var currentTime = startTime.AddMinutes(i * interval);
-                var concentration = CalculateTotalConcentration(doses, currentTime);
-                points.Add((currentTime, concentration));
+                double total = 0;
+                foreach (var p in doseParams)
+                {
+                    double hoursElapsed = (currentTime - p.TimeTaken).TotalHours;
+                    if (hoursElapsed < 0) continue;
+                    double conc = p.A * (Math.Exp(-eliminationConstant * hoursElapsed) - Math.Exp(-absorptionConstant * hoursElapsed));
+                    if (conc > 0) total += conc;
+                }
+                points.Add((currentTime, total));
             }
 
             return points;

--- a/Core/Services/ParacetamolCalculator.cs
+++ b/Core/Services/ParacetamolCalculator.cs
@@ -71,11 +71,25 @@ namespace MoleculeEfficienceTracker.Core.Services
             var timeSpan = endTime - startTime;
             var interval = timeSpan.TotalMinutes / pointCount;
 
+            var doseParams = doses.Select(d => new
+            {
+                d.TimeTaken,
+                A = (d.DoseMg * BIOAVAILABILITY * absorptionConstant) /
+                    (d.WeightKg * VOLUME_DISTRIBUTION_L_PER_KG * (absorptionConstant - eliminationConstant))
+            }).ToList();
+
             for (int i = 0; i <= pointCount; i++)
             {
                 var currentTime = startTime.AddMinutes(i * interval);
-                var concentration = CalculateTotalConcentration(doses, currentTime);
-                points.Add((currentTime, concentration));
+                double total = 0;
+                foreach (var p in doseParams)
+                {
+                    double hoursElapsed = (currentTime - p.TimeTaken).TotalHours;
+                    if (hoursElapsed < 0) continue;
+                    double conc = p.A * (Math.Exp(-eliminationConstant * hoursElapsed) - Math.Exp(-absorptionConstant * hoursElapsed));
+                    if (conc > 0) total += conc;
+                }
+                points.Add((currentTime, total));
             }
 
             return points;


### PR DESCRIPTION
## Summary
- generate chart data in the background and update using `ObservableRangeCollection`
- lower timer frequency to reduce redraws
- optimise `GenerateGraph` in all calculators by precomputing constants

## Testing
- `dotnet build --no-restore` *(fails: workloads not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846d3839f6c833080703b513d61beab