### PR TITLE
Add multi-molecule pain relief page

### DIFF
--- a/BaseMoleculePage.cs
+++ b/BaseMoleculePage.cs
@@ -111,10 +111,10 @@ namespace MoleculeEfficienceTracker
                 Doses.Add(dose);
             }
 
-            UpdateAllDisplays();
+            await UpdateAllDisplays();
         }
 
-        private async void UpdateAllDisplays()
+        protected virtual async Task UpdateAllDisplays()
         {
             UpdateConcentrationDisplay();
             await UpdateChart(); // Rendre asynchrone si UpdateChart l'est
@@ -218,7 +218,7 @@ namespace MoleculeEfficienceTracker
             return null;
         }
 
-        protected async Task UpdateChart()
+        protected virtual async Task UpdateChart()
         {
             var chart = ChartControl; // Utiliser la propriété abstraite
 

--- a/BaseMoleculePage.cs
+++ b/BaseMoleculePage.cs
@@ -144,7 +144,8 @@ namespace MoleculeEfficienceTracker
                 DateTime dateTime = selectedDate.Add(selectedTime);
 
                 double weight = UserPreferences.GetWeightKg();
-                DoseEntry dose = new DoseEntry(dateTime, doseMg, weight);
+                // Enregistrer la clé de molécule pour permettre l'agrégation multi-molécules
+                DoseEntry dose = new DoseEntry(dateTime, doseMg, weight, MoleculeKey);
 
                 Doses.Insert(0, dose);
                 DoseInputControl.Text = "";

--- a/Core/Models/DoseEntry.cs
+++ b/Core/Models/DoseEntry.cs
@@ -8,12 +8,14 @@ namespace MoleculeEfficienceTracker.Core.Models
         public double DoseMg { get; set; }
         public double WeightKg { get; set; } = 72.0; // Poids par défaut si non renseigné
         public string Id { get; set; } = Guid.NewGuid().ToString(); // Ajout pour MAUI
+        public string MoleculeKey { get; set; } = string.Empty; // Identifie la molécule
 
-        public DoseEntry(DateTime timeTaken, double doseMg, double weightKg = 72.0)
+        public DoseEntry(DateTime timeTaken, double doseMg, double weightKg = 72.0, string moleculeKey = "")
         {
             TimeTaken = timeTaken;
             DoseMg = doseMg;
             WeightKg = weightKg;
+            MoleculeKey = moleculeKey;
         }
 
         public DoseEntry() { }

--- a/Core/Services/CombinedPainReliefCalculator.cs
+++ b/Core/Services/CombinedPainReliefCalculator.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MoleculeEfficienceTracker.Core.Models;
+
+namespace MoleculeEfficienceTracker.Core.Services
+{
+    /// <summary>
+    /// Calculator combining Paracetamol and Ibuprofen effects.
+    /// Concentration returned by this calculator represents the summed effect percentage.
+    /// </summary>
+    public class CombinedPainReliefCalculator : IMoleculeCalculator
+    {
+        public string DisplayName => "Antidouleur";
+        public string DoseUnit => "mg";
+        public string ConcentrationUnit => "%";
+
+        private readonly ParacetamolCalculator _paraCalc = new();
+        private readonly IbuprofeneCalculator _ibuCalc = new();
+        // EC50 approximations for an Emax model
+        private readonly PharmacodynamicModel _paraPd = new(ParacetamolCalculator.MODERATE_THRESHOLD);
+        private readonly PharmacodynamicModel _ibuPd = new(12.0);
+
+        private IEnumerable<DoseEntry> Filter(List<DoseEntry> doses, string key)
+        {
+            return doses.Where(d => string.Equals(d.MoleculeKey, key, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public double CalculateSingleDoseConcentration(DoseEntry dose, DateTime time)
+        {
+            if (string.Equals(dose.MoleculeKey, "paracetamol", StringComparison.OrdinalIgnoreCase))
+            {
+                double c = _paraCalc.CalculateSingleDoseConcentration(dose, time);
+                return _paraPd.GetEffectPercent(c);
+            }
+            if (string.Equals(dose.MoleculeKey, "ibuprofen", StringComparison.OrdinalIgnoreCase))
+            {
+                double c = _ibuCalc.CalculateSingleDoseConcentration(dose, time);
+                return _ibuPd.GetEffectPercent(c);
+            }
+            return 0;
+        }
+
+        public double CalculateTotalConcentration(List<DoseEntry> doses, DateTime time)
+        {
+            double paraConc = _paraCalc.CalculateTotalConcentration(Filter(doses, "paracetamol").ToList(), time);
+            double ibuConc = _ibuCalc.CalculateTotalConcentration(Filter(doses, "ibuprofen").ToList(), time);
+            double effectPara = _paraPd.GetEffectPercent(paraConc);
+            double effectIbu = _ibuPd.GetEffectPercent(ibuConc);
+            return effectPara + effectIbu;
+        }
+
+        public double CalculateTotalAmount(List<DoseEntry> doses, DateTime time)
+        {
+            return CalculateTotalConcentration(doses, time);
+        }
+
+        public double GetDoseDisplayValueInConcentrationUnit(DoseEntry dose)
+        {
+            return dose.DoseMg;
+        }
+
+        public List<(DateTime Time, double Concentration)> GenerateGraph(List<DoseEntry> doses, DateTime startTime, DateTime endTime, int points = 200)
+        {
+            var list = new List<(DateTime, double)>();
+            var span = endTime - startTime;
+            var interval = span.TotalMinutes / points;
+            for (int i = 0; i <= points; i++)
+            {
+                DateTime t = startTime.AddMinutes(i * interval);
+                list.Add((t, CalculateTotalConcentration(doses, t)));
+            }
+            return list;
+        }
+
+        public (List<(DateTime Time, double EffectPara)>, List<(DateTime Time, double EffectIbu)>, List<(DateTime Time, double EffectTotal)>) GenerateEffectGraph(List<DoseEntry> doses, DateTime startTime, DateTime endTime, int points = 200)
+        {
+            var span = endTime - startTime;
+            var interval = span.TotalMinutes / points;
+            var paraList = new List<(DateTime, double)>();
+            var ibuList = new List<(DateTime, double)>();
+            var totalList = new List<(DateTime, double)>();
+            for (int i = 0; i <= points; i++)
+            {
+                DateTime t = startTime.AddMinutes(i * interval);
+                double paraConc = _paraCalc.CalculateTotalConcentration(Filter(doses, "paracetamol").ToList(), t);
+                double ibuConc = _ibuCalc.CalculateTotalConcentration(Filter(doses, "ibuprofen").ToList(), t);
+                double effectPara = _paraPd.GetEffectPercent(paraConc);
+                double effectIbu = _ibuPd.GetEffectPercent(ibuConc);
+                paraList.Add((t, effectPara));
+                ibuList.Add((t, effectIbu));
+                totalList.Add((t, effectPara + effectIbu));
+            }
+            return (paraList, ibuList, totalList);
+        }
+    }
+}

--- a/Core/Services/CombinedPainReliefCalculator.cs
+++ b/Core/Services/CombinedPainReliefCalculator.cs
@@ -29,6 +29,7 @@ namespace MoleculeEfficienceTracker.Core.Services
         public double StrongPercent { get; }
         public double ModeratePercent { get; }
         public double LightPercent { get; }
+        public double NegligibleEffect { get; }
 
         public CombinedPainReliefCalculator()
         {
@@ -54,6 +55,9 @@ namespace MoleculeEfficienceTracker.Core.Services
             LightPercent = ComputeUnifiedPercent(
                 ParacetamolCalculator.LIGHT_THRESHOLD,
                 IbuprofeneCalculator.LIGHT_THRESHOLD);
+            NegligibleEffect = ComputeUnifiedPercent(
+            ParacetamolCalculator.NEGLIGIBLE_THRESHOLD,
+            IbuprofeneCalculator.NEGLIGIBLE_THRESHOLD);
         }
 
         private double ComputeUnifiedPercent(double paraConcentration, double ibuConcentration)

--- a/Core/Services/ParacetamolCalculator.cs
+++ b/Core/Services/ParacetamolCalculator.cs
@@ -20,7 +20,7 @@ namespace MoleculeEfficienceTracker.Core.Services
         public const double STRONG_THRESHOLD = 8.5;      // mg/L : effet fort, pic après 1g
         public const double MODERATE_THRESHOLD = 5.0;    // mg/L : effet net
         public const double LIGHT_THRESHOLD = 2.0;        // mg/L : effet léger
-        public const double NEGLIGIBLE_THRESHOLD = 1.5;   // mg/L : effet négligeable
+        public const double NEGLIGIBLE_THRESHOLD = 0.8;   // mg/L : effet négligeable
 
         private readonly double eliminationConstant; // ke
         private readonly double absorptionConstant; // ka

--- a/IbuprofenePage.xaml.cs
+++ b/IbuprofenePage.xaml.cs
@@ -28,6 +28,7 @@ namespace MoleculeEfficienceTracker
         private Label EffectPowerLabel => EffectPower;
 
         private readonly PharmacodynamicModel _pdModel = new PharmacodynamicModel(12.0);
+        private readonly DataPersistenceService _painService = new("pain_relief");
 
         protected override string DoseAnnotationIcon => "💊";
         protected override TimeSpan GraphDataStartOffset => TimeSpan.FromDays(-7);
@@ -41,6 +42,33 @@ namespace MoleculeEfficienceTracker
         {
             InitializeComponent();
             base.InitializePageUI();
+        }
+
+        private async Task SyncPainReliefAsync()
+        {
+            var combined = await _painService.LoadDosesAsync();
+            combined.RemoveAll(d => d.MoleculeKey.Equals("ibuprofen", StringComparison.OrdinalIgnoreCase) || d.MoleculeKey.Equals("ibuprofene", StringComparison.OrdinalIgnoreCase));
+            combined.AddRange(Doses.Select(d => { if (string.IsNullOrEmpty(d.MoleculeKey)) d.MoleculeKey = "ibuprofene"; return d; }));
+            combined = combined.GroupBy(d => d.Id).Select(g => g.First()).OrderByDescending(d => d.TimeTaken).ToList();
+            await _painService.SaveDosesAsync(combined);
+        }
+
+        private new async void OnAddDoseClicked(object sender, EventArgs e)
+        {
+            base.OnAddDoseClicked(sender, e);
+            await SyncPainReliefAsync();
+        }
+
+        private new async void OnDeleteDoseClicked(object sender, EventArgs e)
+        {
+            base.OnDeleteDoseClicked(sender, e);
+            await SyncPainReliefAsync();
+        }
+
+        private new async void OnClearAllDataClicked(object sender, EventArgs e)
+        {
+            base.OnClearAllDataClicked(sender, e);
+            await _painService.DeleteAllDataAsync();
         }
 
         protected override void UpdateMoleculeSpecificConcentrationInfo(List<DoseEntry> doses, DateTime currentTime)
@@ -99,7 +127,30 @@ namespace MoleculeEfficienceTracker
 
         protected override async Task OnBeforeLoadDataAsync()
         {
-            await base.OnBeforeLoadDataAsync(); // Appel à l'implémentation de base (facultatif ici car vide)
+            await base.OnBeforeLoadDataAsync();
+
+            var own = await PersistenceService.LoadDosesAsync();
+            var combined = await _painService.LoadDosesAsync();
+
+            foreach (var d in own)
+            {
+                if (string.IsNullOrEmpty(d.MoleculeKey)) d.MoleculeKey = "ibuprofene";
+            }
+
+            var fromCombined = combined.Where(d => d.MoleculeKey.Equals("ibuprofen", StringComparison.OrdinalIgnoreCase) || d.MoleculeKey.Equals("ibuprofene", StringComparison.OrdinalIgnoreCase)).ToList();
+
+            var merged = own
+                .Concat(fromCombined)
+                .GroupBy(d => d.Id)
+                .Select(g => g.First())
+                .OrderByDescending(d => d.TimeTaken)
+                .ToList();
+
+            await PersistenceService.SaveDosesAsync(merged);
+            combined.RemoveAll(d => d.MoleculeKey.Equals("ibuprofen", StringComparison.OrdinalIgnoreCase) || d.MoleculeKey.Equals("ibuprofene", StringComparison.OrdinalIgnoreCase));
+            combined.AddRange(merged);
+            combined = combined.GroupBy(d => d.Id).Select(g => g.First()).OrderByDescending(d => d.TimeTaken).ToList();
+            await _painService.SaveDosesAsync(combined);
         }
 
         private void AddThresholdAnnotation(double yValue, string text, Color color)

--- a/IbuprofenePage.xaml.cs
+++ b/IbuprofenePage.xaml.cs
@@ -53,10 +53,10 @@ namespace MoleculeEfficienceTracker
 
                 string text = level switch
                 {
-                    EffectLevel.Strong => "Effet fort",
-                    EffectLevel.Moderate => "Effet modéré",
-                    EffectLevel.Light => "Effet léger",
-                    _ => "Effet négligeable"
+                    EffectLevel.Strong => "Fort",
+                    EffectLevel.Moderate => "Net",
+                    EffectLevel.Light => "Léger",
+                    _ => "Négligeable"
                 };
 
                 Color color = level switch
@@ -131,7 +131,7 @@ namespace MoleculeEfficienceTracker
             if (Calculator is IbuprofeneCalculator calc && ChartControl != null)
             {
                 AddThresholdAnnotation(IbuprofeneCalculator.STRONG_THRESHOLD, "Fort", Colors.Orange);
-                AddThresholdAnnotation(IbuprofeneCalculator.MODERATE_THRESHOLD, "Modéré", Colors.YellowGreen);
+                AddThresholdAnnotation(IbuprofeneCalculator.MODERATE_THRESHOLD, "Net", Colors.YellowGreen);
                 AddThresholdAnnotation(IbuprofeneCalculator.LIGHT_THRESHOLD, "Léger", Colors.Green);
                 AddThresholdAnnotation(IbuprofeneCalculator.NEGLIGIBLE_THRESHOLD, "Imperceptible", Colors.Grey);
             }

--- a/MainTabsPage.xaml
+++ b/MainTabsPage.xaml
@@ -14,6 +14,8 @@
     <local:ParacetamolPage Title="Paracétamol" IconImageSource="💊" />
     <!-- Onglet Ibuprofène -->
     <local:IbuprofenePage Title="Ibuprofène" IconImageSource="💊" />
+    <!-- Onglet Anti-douleur -->
+    <local:PainReliefPage Title="Anti-douleur" IconImageSource="💊" />
 
     <!-- Onglet Alcool -->
     <local:AlcoholPage Title="Alcool" IconImageSource="🍾" />

--- a/PainReliefPage.xaml
+++ b/PainReliefPage.xaml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<local:BaseMoleculePage x:Class="MoleculeEfficienceTracker.PainReliefPage"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:MoleculeEfficienceTracker"
+             xmlns:coreServices="clr-namespace:MoleculeEfficienceTracker.Core.Services"
+             xmlns:chart="clr-namespace:Syncfusion.Maui.Charts;assembly=Syncfusion.Maui.Charts"
+             x:TypeArguments="coreServices:CombinedPainReliefCalculator"
+             Title="Anti-douleur">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Styles/ModernStyles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <Color x:Key="MainBgColor">#F0F4F8</Color>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ContentPage.Background>
+        <SolidColorBrush Color="{StaticResource MainBgColor}" />
+    </ContentPage.Background>
+    <ScrollView>
+        <VerticalStackLayout Style="{StaticResource PageRootLayoutStyle}"
+                             BackgroundColor="{StaticResource MainBgColor}">
+            <!-- ADD DOSE -->
+            <Frame Style="{StaticResource CardFrameStyle}" Margin="0,0,0,0">
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="💊 Ajouter une dose" FontSize="16" FontAttributes="Bold" TextColor="#3182CE" />
+                    <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+                        <Label Grid.Row="0" Grid.Column="0" Text="Molécule:" VerticalOptions="Center" />
+                        <Picker x:Name="MoleculePicker" Grid.Row="0" Grid.Column="1">
+                            <Picker.Items>
+                                <x:String>paracetamol</x:String>
+                                <x:String>ibuprofen</x:String>
+                            </Picker.Items>
+                        </Picker>
+                        <Label Grid.Row="1" Grid.Column="0" Text="Dose (mg):" VerticalOptions="Center" />
+                        <Frame Grid.Row="1" Grid.Column="1" CornerRadius="8" Padding="0" BackgroundColor="#EBF8FF" HasShadow="False" VerticalOptions="Center" HeightRequest="32">
+                            <Entry x:Name="DoseEntry" Placeholder="500" Keyboard="Numeric" BackgroundColor="Transparent" HeightRequest="32" VerticalOptions="Center" />
+                        </Frame>
+                        <Label Grid.Row="2" Grid.Column="0" Text="Date/Heure:" VerticalOptions="Center" />
+                        <HorizontalStackLayout Grid.Row="2" Grid.Column="1" Spacing="8">
+                            <DatePicker x:Name="DatePicker" />
+                            <TimePicker x:Name="TimePicker" Format="HH:mm" />
+                        </HorizontalStackLayout>
+                    </Grid>
+                    <Button Text="Ajouter la dose" Clicked="OnAddPainDoseClicked" Style="{StaticResource PrimaryButtonStyle}" />
+                </VerticalStackLayout>
+            </Frame>
+            <!-- GRAPH -->
+            <Frame Style="{StaticResource CardFrameStyle}" BackgroundColor="#E6FFFA">
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Effet estimé" FontSize="20" FontAttributes="Bold" TextColor="#319795" />
+                    <Label x:Name="ConcentrationLabel" FontSize="32" FontAttributes="Bold" TextColor="#22543D" HorizontalOptions="Center" />
+                    <Label x:Name="LastUpdateLabel" FontSize="14" TextColor="#718096" HorizontalOptions="Center" />
+                    <Frame Padding="10" CornerRadius="10" BackgroundColor="White" HasShadow="True" Margin="0,8,0,0" HeightRequest="320">
+                        <chart:SfCartesianChart x:Name="ConcentrationChart">
+                            <chart:SfCartesianChart.TrackballBehavior>
+                                <chart:ChartTrackballBehavior ShowLabel="True" ShowMarkers="True" ShowLine="True" DisplayMode="FloatAllPoints" />
+                            </chart:SfCartesianChart.TrackballBehavior>
+                            <chart:SfCartesianChart.ZoomPanBehavior>
+                                <chart:ChartZoomPanBehavior ZoomMode="X" EnablePanning="True" />
+                            </chart:SfCartesianChart.ZoomPanBehavior>
+                            <chart:SfCartesianChart.XAxes>
+                                <chart:DateTimeAxis ShowMajorGridLines="True" ShowMinorGridLines="False" EdgeLabelsDrawingMode="Fit" LabelCreated="ChartXAxis_LabelCreated">
+                                    <chart:DateTimeAxis.LabelStyle>
+                                        <chart:ChartAxisLabelStyle LabelFormat="dd/MM HH:mm" FontSize="10" TextColor="#31465D" />
+                                    </chart:DateTimeAxis.LabelStyle>
+                                    <chart:DateTimeAxis.MajorGridLineStyle>
+                                        <chart:ChartLineStyle Stroke="#E5E7EB" StrokeWidth="1" />
+                                    </chart:DateTimeAxis.MajorGridLineStyle>
+                                </chart:DateTimeAxis>
+                            </chart:SfCartesianChart.XAxes>
+                            <chart:SfCartesianChart.YAxes>
+                                <chart:NumericalAxis Minimum="0" Maximum="200">
+                                    <chart:NumericalAxis.LabelStyle>
+                                        <chart:ChartAxisLabelStyle FontSize="10" TextColor="#31465D" />
+                                    </chart:NumericalAxis.LabelStyle>
+                                    <chart:NumericalAxis.MajorGridLineStyle>
+                                        <chart:ChartLineStyle Stroke="#E5E7EB" StrokeWidth="1" />
+                                    </chart:NumericalAxis.MajorGridLineStyle>
+                                </chart:NumericalAxis>
+                            </chart:SfCartesianChart.YAxes>
+                            <chart:SplineSeries ItemsSource="{Binding ParacetamolChartData}" XBindingPath="Time" YBindingPath="Concentration" Stroke="Blue" StrokeWidth="1.5" />
+                            <chart:SplineSeries ItemsSource="{Binding IbuprofenChartData}" XBindingPath="Time" YBindingPath="Concentration" Stroke="Black" StrokeWidth="1.5" />
+                            <chart:SplineSeries ItemsSource="{Binding TotalChartData}" XBindingPath="Time" YBindingPath="Concentration" Stroke="Green" StrokeWidth="1.5" />
+                        </chart:SfCartesianChart>
+                    </Frame>
+                </VerticalStackLayout>
+            </Frame>
+            <!-- DOSES LISTES -->
+            <Frame Style="{StaticResource CardFrameStyle}" BackgroundColor="#FFFDE7">
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Paracétamol" FontSize="20" FontAttributes="Bold" TextColor="#B7791F" />
+                    <CollectionView x:Name="ParacetamolCollection" ItemsSource="{Binding ParacetamolDoses}" MaximumHeightRequest="150">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate>
+                                <Frame BackgroundColor="#FAF5FF" CornerRadius="8" Padding="10,6" Margin="0,3" HasShadow="False">
+                                    <Grid ColumnDefinitions="*,*,Auto">
+                                        <Label Grid.Column="0" Text="{Binding TimeTaken, StringFormat='{0:dd/MM HH:mm}'}" VerticalOptions="Center" TextColor="Black" />
+                                        <Label Grid.Column="1" Text="{Binding DoseMg, Converter={StaticResource DoseDisplayConverter}, ConverterParameter=mg}" VerticalOptions="Center" HorizontalOptions="Center" TextColor="Black" />
+                                        <Button Grid.Column="2" Text="❌" CommandParameter="{Binding Id}" Clicked="OnDeleteDoseClickedCustom" Style="{StaticResource DeleteButtonStyle}" WidthRequest="38" HeightRequest="28" />
+                                    </Grid>
+                                </Frame>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                    <Label Text="Ibuprofène" FontSize="20" FontAttributes="Bold" TextColor="#B7791F" />
+                    <CollectionView x:Name="IbuprofenCollection" ItemsSource="{Binding IbuprofenDoses}" MaximumHeightRequest="150">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate>
+                                <Frame BackgroundColor="#FAF5FF" CornerRadius="8" Padding="10,6" Margin="0,3" HasShadow="False">
+                                    <Grid ColumnDefinitions="*,*,Auto">
+                                        <Label Grid.Column="0" Text="{Binding TimeTaken, StringFormat='{0:dd/MM HH:mm}'}" VerticalOptions="Center" TextColor="Black" />
+                                        <Label Grid.Column="1" Text="{Binding DoseMg, Converter={StaticResource DoseDisplayConverter}, ConverterParameter=mg}" VerticalOptions="Center" HorizontalOptions="Center" TextColor="Black" />
+                                        <Button Grid.Column="2" Text="❌" CommandParameter="{Binding Id}" Clicked="OnDeleteDoseClickedCustom" Style="{StaticResource DeleteButtonStyle}" WidthRequest="38" HeightRequest="28" />
+                                    </Grid>
+                                </Frame>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                    <Label x:Name="EmptyDosesLabel" Text="Aucune dose enregistrée 💤" IsVisible="False" Style="{StaticResource EmptyLabelStyle}" />
+                </VerticalStackLayout>
+            </Frame>
+            <Frame Style="{StaticResource CardFrameStyle}" Padding="12" BackgroundColor="#EDF2F7">
+                <HorizontalStackLayout Spacing="22" HorizontalOptions="Center">
+                    <Button Text="💾 Exporter" Clicked="OnExportDataClicked" Style="{StaticResource PrimaryButtonStyle}" />
+                    <Button Text="🗑️ Effacer tout" Clicked="OnClearAllDataClicked" Style="{StaticResource DeleteButtonStyle}" />
+                </HorizontalStackLayout>
+            </Frame>
+        </VerticalStackLayout>
+    </ScrollView>
+</local:BaseMoleculePage>

--- a/PainReliefPage.xaml
+++ b/PainReliefPage.xaml
@@ -71,7 +71,7 @@
                                 </chart:DateTimeAxis>
                             </chart:SfCartesianChart.XAxes>
                             <chart:SfCartesianChart.YAxes>
-                                <chart:NumericalAxis Minimum="0" Maximum="200">
+                                <chart:NumericalAxis Minimum="0" Maximum="110">
                                     <chart:NumericalAxis.LabelStyle>
                                         <chart:ChartAxisLabelStyle FontSize="10" TextColor="#31465D" />
                                     </chart:NumericalAxis.LabelStyle>

--- a/PainReliefPage.xaml
+++ b/PainReliefPage.xaml
@@ -52,6 +52,9 @@
                     <Label Text="Effet estimé" FontSize="20" FontAttributes="Bold" TextColor="#319795" />
                     <Label x:Name="ConcentrationLabel" FontSize="32" FontAttributes="Bold" TextColor="#22543D" HorizontalOptions="Center" />
                     <Label x:Name="LastUpdateLabel" FontSize="14" TextColor="#718096" HorizontalOptions="Center" />
+                    <Label x:Name="EffectPower" FontSize="14" TextColor="#22543D" HorizontalOptions="Center" />
+                    <Label x:Name="EffectStatus" FontSize="14" HorizontalOptions="Center" TextColor="Green" Text="" />
+                    <Label x:Name="EffectPrediction" FontSize="12" HorizontalOptions="Center" TextColor="Red" Text="" />
                     <Frame Padding="10" CornerRadius="10" BackgroundColor="White" HasShadow="True" Margin="0,8,0,0" HeightRequest="320">
                         <chart:SfCartesianChart x:Name="ConcentrationChart">
                             <chart:SfCartesianChart.TrackballBehavior>

--- a/PainReliefPage.xaml
+++ b/PainReliefPage.xaml
@@ -49,10 +49,8 @@
             <!-- GRAPH -->
             <Frame Style="{StaticResource CardFrameStyle}" BackgroundColor="#E6FFFA">
                 <VerticalStackLayout Spacing="8">
-                    <Label Text="Effet estimé" FontSize="20" FontAttributes="Bold" TextColor="#319795" />
                     <Label x:Name="ConcentrationLabel" FontSize="32" FontAttributes="Bold" TextColor="#22543D" HorizontalOptions="Center" />
                     <Label x:Name="LastUpdateLabel" FontSize="14" TextColor="#718096" HorizontalOptions="Center" />
-                    <Label x:Name="EffectPower" FontSize="14" TextColor="#22543D" HorizontalOptions="Center" />
                     <Label x:Name="EffectStatus" FontSize="14" HorizontalOptions="Center" TextColor="Green" Text="" />
                     <Label x:Name="EffectPrediction" FontSize="12" HorizontalOptions="Center" TextColor="Red" Text="" />
                     <Frame Padding="10" CornerRadius="10" BackgroundColor="White" HasShadow="True" Margin="0,8,0,0" HeightRequest="320">
@@ -69,7 +67,7 @@
                                         <chart:ChartAxisLabelStyle LabelFormat="dd/MM HH:mm" FontSize="10" TextColor="#31465D" />
                                     </chart:DateTimeAxis.LabelStyle>
                                     <chart:DateTimeAxis.MajorGridLineStyle>
-                                        <chart:ChartLineStyle Stroke="#E5E7EB" StrokeWidth="1" />
+                                        <chart:ChartLineStyle  StrokeWidth="1" />
                                     </chart:DateTimeAxis.MajorGridLineStyle>
                                 </chart:DateTimeAxis>
                             </chart:SfCartesianChart.XAxes>
@@ -79,13 +77,13 @@
                                         <chart:ChartAxisLabelStyle FontSize="10" TextColor="#31465D" />
                                     </chart:NumericalAxis.LabelStyle>
                                     <chart:NumericalAxis.MajorGridLineStyle>
-                                        <chart:ChartLineStyle Stroke="#E5E7EB" StrokeWidth="1" />
+                                        <chart:ChartLineStyle StrokeWidth="1" />
                                     </chart:NumericalAxis.MajorGridLineStyle>
                                 </chart:NumericalAxis>
                             </chart:SfCartesianChart.YAxes>
-                            <chart:SplineSeries ItemsSource="{Binding ParacetamolChartData}" XBindingPath="Time" YBindingPath="Concentration" Stroke="Blue" StrokeWidth="1.5" />
-                            <chart:SplineSeries ItemsSource="{Binding IbuprofenChartData}" XBindingPath="Time" YBindingPath="Concentration" Stroke="Black" StrokeWidth="1.5" />
-                            <chart:SplineSeries ItemsSource="{Binding TotalChartData}" XBindingPath="Time" YBindingPath="Concentration" Stroke="Green" StrokeWidth="1.5" />
+                            <chart:SplineSeries ItemsSource="{Binding ParacetamolChartData}" XBindingPath="Time" YBindingPath="Concentration"  StrokeWidth="1.5" />
+                            <chart:SplineSeries ItemsSource="{Binding IbuprofenChartData}" XBindingPath="Time" YBindingPath="Concentration"  StrokeWidth="1.5" />
+                            <chart:SplineSeries ItemsSource="{Binding TotalChartData}" XBindingPath="Time" YBindingPath="Concentration"  StrokeWidth="1.5" />
                         </chart:SfCartesianChart>
                     </Frame>
                 </VerticalStackLayout>

--- a/PainReliefPage.xaml.cs
+++ b/PainReliefPage.xaml.cs
@@ -1,5 +1,6 @@
 using MoleculeEfficienceTracker.Core.Models;
 using MoleculeEfficienceTracker.Core.Services;
+using MoleculeEfficienceTracker.Core.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -7,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Syncfusion.Maui.Charts;
 using Microsoft.Maui.Graphics;
+
 
 namespace MoleculeEfficienceTracker
 {
@@ -23,7 +25,7 @@ namespace MoleculeEfficienceTracker
 
         private Label EffectStatusLabel => EffectStatus;
         private Label EffectEndPredictionLabel => EffectPrediction;
-        private Label EffectPowerLabel => EffectPower;
+        
 
         protected override string DoseAnnotationIcon => "💊";
         protected override TimeSpan GraphDataStartOffset => TimeSpan.FromDays(-7);
@@ -118,12 +120,7 @@ namespace MoleculeEfficienceTracker
         protected override void UpdateMoleculeSpecificConcentrationInfo(List<DoseEntry> doses, DateTime currentTime)
         {
             double effect = Calculator.CalculateTotalConcentration(doses, currentTime);
-            ConcentrationOutputLabel.Text = $"Effet total : {effect:F0} %";
-            if (EffectPowerLabel != null)
-            {
-                EffectPowerLabel.Text = $"Saturation : {effect:F0} %";
-                EffectPowerLabel.IsVisible = true;
-            }
+            ConcentrationOutputLabel.Text = $"Saturation : {effect:F0} %";
 
             EffectLevel level = Calculator.GetCombinedEffectLevel(doses, currentTime);
             if (EffectStatusLabel != null)
@@ -131,9 +128,9 @@ namespace MoleculeEfficienceTracker
                 string text = level switch
                 {
                     EffectLevel.Strong => "Effet fort",
-                    EffectLevel.Moderate => "Effet modéré",
+                    EffectLevel.Moderate => "Effet net",
                     EffectLevel.Light => "Effet léger",
-                    _ => "Effet négligeable"
+                    _ => "Négligeable"
                 };
                 Color color = level switch
                 {
@@ -153,7 +150,7 @@ namespace MoleculeEfficienceTracker
                 if (endTime.HasValue && endTime.Value > currentTime)
                 {
                     var remaining = endTime.Value - currentTime;
-                    EffectEndPredictionLabel.Text = $"Effet négligeable estimé dans {remaining.TotalHours:F1} heures";
+                    EffectEndPredictionLabel.Text = $"Effet négligeable dans {remaining.TotalHours:F1} heures";
                 }
                 else
                 {

--- a/PainReliefPage.xaml.cs
+++ b/PainReliefPage.xaml.cs
@@ -1,0 +1,164 @@
+using MoleculeEfficienceTracker.Core.Models;
+using MoleculeEfficienceTracker.Core.Services;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Syncfusion.Maui.Charts;
+using Microsoft.Maui.Graphics;
+
+namespace MoleculeEfficienceTracker
+{
+    public partial class PainReliefPage : BaseMoleculePage<CombinedPainReliefCalculator>
+    {
+        protected override Entry DoseInputControl => DoseEntry;
+        protected override DatePicker DatePickerControl => DatePicker;
+        protected override TimePicker TimePickerControl => TimePicker;
+        protected override Label ConcentrationOutputLabel => ConcentrationLabel;
+        protected override Label LastUpdateOutputLabel => LastUpdateLabel;
+        protected override SfCartesianChart ChartControl => ConcentrationChart;
+        protected override CollectionView DosesDisplayCollection => ParacetamolCollection;
+        protected override Label EmptyStateIndicatorLabel => EmptyDosesLabel;
+
+        protected override string DoseAnnotationIcon => "💊";
+        protected override TimeSpan GraphDataStartOffset => TimeSpan.FromDays(-7);
+        protected override TimeSpan GraphDataEndOffset => TimeSpan.FromDays(3);
+        protected override int GraphDataNumberOfPoints => 10 * 24 * 2;
+        protected override TimeSpan InitialVisibleStartOffset => TimeSpan.FromHours(-12);
+        protected override TimeSpan InitialVisibleEndOffset => TimeSpan.FromHours(12);
+
+        public ObservableCollection<DoseEntry> ParacetamolDoses { get; } = new();
+        public ObservableCollection<DoseEntry> IbuprofenDoses { get; } = new();
+        public ObservableRangeCollection<ChartDataPoint> ParacetamolChartData { get; } = new();
+        public ObservableRangeCollection<ChartDataPoint> IbuprofenChartData { get; } = new();
+        public ObservableRangeCollection<ChartDataPoint> TotalChartData { get; } = new();
+
+        public PainReliefPage() : base("pain_relief")
+        {
+            InitializeComponent();
+            base.InitializePageUI();
+            Doses.CollectionChanged += (s, e) => RefreshDoseGroups();
+            RefreshDoseGroups();
+        }
+
+        private void RefreshDoseGroups()
+        {
+            ParacetamolDoses.Clear();
+            IbuprofenDoses.Clear();
+            foreach (var d in Doses)
+            {
+                if (d.MoleculeKey == "paracetamol") ParacetamolDoses.Add(d);
+                else if (d.MoleculeKey == "ibuprofen") IbuprofenDoses.Add(d);
+            }
+        }
+
+        private async void OnAddPainDoseClicked(object sender, EventArgs e)
+        {
+            if (double.TryParse(DoseEntry.Text, out double doseMg) && doseMg > 0 && MoleculePicker.SelectedItem is string molecule)
+            {
+                DateTime selectedDate = DatePicker.Date;
+                DateTime dateTime = selectedDate.Add(TimePicker.Time);
+                double weight = UserPreferences.GetWeightKg();
+                DoseEntry dose = new DoseEntry(dateTime, doseMg, weight, molecule);
+                Doses.Insert(0, dose);
+                DoseEntry.Text = string.Empty;
+                RefreshDoseGroups();
+
+                UpdateConcentrationDisplay();
+                await UpdateChart();
+                UpdateDoseAnnotations();
+                await SaveDataAsync();
+                await AlertService.ShowAlertAsync("✅", $"Dose {doseMg}mg {molecule} ajoutée pour {dateTime:dd/MM HH:mm}");
+            }
+            else
+            {
+                await AlertService.ShowAlertAsync("❌", "Veuillez entrer une dose valide");
+            }
+
+            if (sender is Button btn) AnimateButton(btn);
+            UpdateEmptyState();
+        }
+
+        private async void OnDeleteDoseClickedCustom(object sender, EventArgs e)
+        {
+            if (sender is Button button && button.CommandParameter is string doseId)
+            {
+                DoseEntry? dose = Doses.FirstOrDefault(d => d.Id == doseId);
+                if (dose != null)
+                {
+                    bool confirm = await DisplayAlert("Supprimer",
+                        $"Supprimer la dose de {dose.DoseMg}mg ({dose.MoleculeKey}) du {dose.TimeTaken:dd/MM HH:mm} ?",
+                        "Oui", "Non");
+
+                    if (confirm)
+                    {
+                        Doses.Remove(dose);
+                        RefreshDoseGroups();
+                        UpdateConcentrationDisplay();
+                        await UpdateChart();
+                        UpdateDoseAnnotations();
+                        await SaveDataAsync();
+                    }
+                }
+            }
+            UpdateEmptyState();
+        }
+
+        protected override async Task UpdateChart()
+        {
+            var chart = ChartControl;
+            if (chart == null) return;
+
+            if (!Doses.Any())
+            {
+                ParacetamolChartData.Clear();
+                IbuprofenChartData.Clear();
+                TotalChartData.Clear();
+                await base.UpdateChart();
+                return;
+            }
+
+            DateTime currentTime = DateTime.Now;
+            DateTime start = currentTime.Add(GraphDataStartOffset);
+            DateTime end = currentTime.Add(GraphDataEndOffset);
+            int points = GraphDataNumberOfPoints;
+
+            List<DoseEntry> copy = Doses.ToList();
+            var result = await Task.Run(() => Calculator.GenerateEffectGraph(copy, start, end, points));
+
+            ParacetamolChartData.ReplaceRange(result.Item1.Select(p => new ChartDataPoint(p.Time, p.EffectPara)));
+            IbuprofenChartData.ReplaceRange(result.Item2.Select(p => new ChartDataPoint(p.Time, p.EffectIbu)));
+            TotalChartData.ReplaceRange(result.Item3.Select(p => new ChartDataPoint(p.Time, p.EffectTotal)));
+
+            if (chart.XAxes?.FirstOrDefault() is DateTimeAxis xAxis)
+            {
+                xAxis.Minimum = start;
+                xAxis.Maximum = end;
+                xAxis.IntervalType = DateTimeIntervalType.Auto;
+                xAxis.Interval = 3;
+
+                DateTime visibleStart = currentTime.Add(InitialVisibleStartOffset);
+                DateTime visibleEnd = currentTime.Add(InitialVisibleEndOffset);
+
+                double totalRange = (end - start).TotalHours;
+                double desiredDuration = (visibleEnd - visibleStart).TotalHours;
+
+                if (totalRange > 0)
+                {
+                    xAxis.ZoomFactor = Math.Max(0.00001, Math.Min(1.0, desiredDuration / totalRange));
+                    double desiredStartOffset = (visibleStart - start).TotalHours;
+                    xAxis.ZoomPosition = desiredStartOffset / totalRange;
+                    xAxis.ZoomPosition = Math.Max(0.0, Math.Min(1.0 - xAxis.ZoomFactor, xAxis.ZoomPosition));
+                }
+                else
+                {
+                    xAxis.ZoomFactor = 1;
+                    xAxis.ZoomPosition = 0;
+                }
+            }
+
+            await chart.FadeTo(0.7, 80);
+            await chart.FadeTo(1.0, 80);
+        }
+    }
+}

--- a/PainReliefPage.xaml.cs
+++ b/PainReliefPage.xaml.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Syncfusion.Maui.Charts;
 using Microsoft.Maui.Graphics;
 
-
 namespace MoleculeEfficienceTracker
 {
     public partial class PainReliefPage : BaseMoleculePage<CombinedPainReliefCalculator>
@@ -129,7 +128,7 @@ namespace MoleculeEfficienceTracker
         protected override void UpdateMoleculeSpecificConcentrationInfo(List<DoseEntry> doses, DateTime currentTime)
         {
             double effect = Calculator.CalculateTotalConcentration(doses, currentTime);
-            ConcentrationOutputLabel.Text = $"Saturation : {effect:F0} %";
+            ConcentrationOutputLabel.Text = $"Effet : {effect:F0} %";
 
             EffectLevel level = Calculator.GetCombinedEffectLevel(doses, currentTime);
             if (EffectStatusLabel != null)
@@ -139,7 +138,7 @@ namespace MoleculeEfficienceTracker
                     EffectLevel.Strong => "Effet fort",
                     EffectLevel.Moderate => "Effet net",
                     EffectLevel.Light => "Effet léger",
-                    _ => "Négligeable"
+                    _ => "Effet négligeable"
                 };
                 Color color = level switch
                 {
@@ -248,9 +247,10 @@ namespace MoleculeEfficienceTracker
         protected override void AddMoleculeSpecificChartAnnotations()
         {
             if (ChartControl == null) return;
-            AddThresholdAnnotation(Calculator.StrongPercent, "Effet fort", Colors.Orange);
-            AddThresholdAnnotation(Calculator.ModeratePercent, "Effet modéré", Colors.YellowGreen);
-            AddThresholdAnnotation(Calculator.LightPercent, "Effet léger", Colors.Green);
+            AddThresholdAnnotation(Calculator.StrongPercent, "Fort", Colors.Orange);
+            AddThresholdAnnotation(Calculator.ModeratePercent, "Net", Colors.YellowGreen);
+            AddThresholdAnnotation(Calculator.LightPercent, "Léger", Colors.Green);
+            AddThresholdAnnotation(Calculator.NegligibleEffect, "Négligeable", Colors.Gray);
         }
 
         protected override async Task UpdateChart()

--- a/PainReliefPage.xaml.cs
+++ b/PainReliefPage.xaml.cs
@@ -212,15 +212,9 @@ namespace MoleculeEfficienceTracker
         protected override void AddMoleculeSpecificChartAnnotations()
         {
             if (ChartControl == null) return;
-            AddThresholdAnnotation(Calculator.ParacetamolStrongPercent, "PCT fort", Colors.Orange);
-            AddThresholdAnnotation(Calculator.ParacetamolModeratePercent, "PCT modéré", Colors.YellowGreen);
-            AddThresholdAnnotation(Calculator.ParacetamolLightPercent, "PCT léger", Colors.Green);
-            AddThresholdAnnotation(Calculator.ParacetamolNegligiblePercent, "PCT imperceptible", Colors.Grey);
-
-            AddThresholdAnnotation(Calculator.IbuprofenStrongPercent, "IBU fort", Colors.Orange);
-            AddThresholdAnnotation(Calculator.IbuprofenModeratePercent, "IBU modéré", Colors.YellowGreen);
-            AddThresholdAnnotation(Calculator.IbuprofenLightPercent, "IBU léger", Colors.Green);
-            AddThresholdAnnotation(Calculator.IbuprofenNegligiblePercent, "IBU imperceptible", Colors.Grey);
+            AddThresholdAnnotation(Calculator.StrongPercent, "Effet fort", Colors.Orange);
+            AddThresholdAnnotation(Calculator.ModeratePercent, "Effet modéré", Colors.YellowGreen);
+            AddThresholdAnnotation(Calculator.LightPercent, "Effet léger", Colors.Green);
         }
 
         protected override async Task UpdateChart()

--- a/ParacetamolPage.xaml.cs
+++ b/ParacetamolPage.xaml.cs
@@ -65,10 +65,10 @@ namespace MoleculeEfficienceTracker
 
                 string text = level switch
                 {
-                    EffectLevel.Strong => "Effet fort",
-                    EffectLevel.Moderate => "Effet modéré",
-                    EffectLevel.Light => "Effet léger",
-                    _ => "Effet négligeable"
+                    EffectLevel.Strong => "Fort",
+                    EffectLevel.Moderate => "Net",
+                    EffectLevel.Light => "Léger",
+                    _ => "Négligeable"
                 };
 
                 Color color = level switch
@@ -98,7 +98,7 @@ namespace MoleculeEfficienceTracker
                     if (endTime.HasValue && endTime.Value > currentTime)
                     {
                         var remaining = endTime.Value - currentTime;
-                        EffectEndPredictionLabel.Text = $"Effet négligeable estimé dans {remaining.TotalHours:F1} heures";
+                        EffectEndPredictionLabel.Text = $"Effet négligeable dans {remaining.TotalHours:F1} heures";
                     }
                     else
                     {
@@ -137,8 +137,8 @@ namespace MoleculeEfficienceTracker
         {
             if (Calculator is ParacetamolCalculator calc && ChartControl != null)
             {
-                AddThresholdAnnotation(ParacetamolCalculator.STRONG_THRESHOLD, "Fort (1g)", Colors.Orange);
-                AddThresholdAnnotation(ParacetamolCalculator.MODERATE_THRESHOLD, "Modéré", Colors.YellowGreen);
+                AddThresholdAnnotation(ParacetamolCalculator.STRONG_THRESHOLD, "Fort", Colors.Orange);
+                AddThresholdAnnotation(ParacetamolCalculator.MODERATE_THRESHOLD, "Net", Colors.YellowGreen);
                 AddThresholdAnnotation(ParacetamolCalculator.LIGHT_THRESHOLD, "Léger", Colors.Green);
                 AddThresholdAnnotation(ParacetamolCalculator.NEGLIGIBLE_THRESHOLD, "Imperceptible", Colors.Grey);
             }


### PR DESCRIPTION
## Summary
- extend `DoseEntry` to carry a `MoleculeKey`
- make `UpdateAllDisplays` and `UpdateChart` overridable
- add `CombinedPainReliefCalculator` for paracetamol and ibuprofen
- implement `PainReliefPage` with three effect curves and per-molecule dose lists
- register the new page in the tabbed navigation

## Testing
- `dotnet build MoleculeEfficienceTracker.sln -v minimal` *(fails: NETSDK1147 workloads missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847d2fddd148330b854d9d48da0d145