### PR TITLE
Improve tab loading performance

### DIFF
--- a/MainTabsPage.xaml
+++ b/MainTabsPage.xaml
@@ -2,20 +2,5 @@
 <TabbedPage
     x:Class="MoleculeEfficienceTracker.MainTabsPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:MoleculeEfficienceTracker">
-  
-    <!-- Onglet Caféine -->
-    <local:CaffeinePage Title="🍵"  />
-    
-    <!-- Onglet Bromazépam -->
-    <local:BromazepamPage Title="🧠"  />
-    <!-- Onglet Anti-douleur -->
-    <local:PainReliefPage Title="🩹" />
-
-    <!-- Onglet Alcool -->
-    <local:AlcoholPage Title="🍾" />
-    <!-- Onglet Paramètres -->
-
-    <local:SettingsPage Title="⚙️" IconImageSource="⚙️" />
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 </TabbedPage>

--- a/MainTabsPage.xaml.cs
+++ b/MainTabsPage.xaml.cs
@@ -1,12 +1,51 @@
 ﻿using Microsoft.Maui.Controls;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace MoleculeEfficienceTracker
 {
     public partial class MainTabsPage : TabbedPage
     {
+        private readonly Dictionary<Page, (Func<Page> factory, ImageSource? icon)> _lazyPages = new();
+
         public MainTabsPage()
         {
             InitializeComponent();
+
+            AddLazyTab("🍵", () => new CaffeinePage());
+            AddLazyTab("🧠", () => new BromazepamPage());
+            AddLazyTab("🩹", () => new PainReliefPage());
+            AddLazyTab("🍾", () => new AlcoholPage());
+            AddLazyTab("⚙️", () => new SettingsPage());
+
+            CurrentPageChanged += async (s, e) => await LoadLazyPageAsync(CurrentPage);
+
+            // Preload the first tab for a smoother startup
+            if (Children.Count > 0)
+                _ = LoadLazyPageAsync(Children[0]);
+        }
+
+        private void AddLazyTab(string title, Func<Page> factory)
+        {
+            var placeholder = new ContentPage { Title = title };
+            _lazyPages[placeholder] = (factory, placeholder.IconImageSource);
+            Children.Add(placeholder);
+        }
+
+        private async Task LoadLazyPageAsync(Page placeholder)
+        {
+            if (!_lazyPages.TryGetValue(placeholder, out var info))
+                return;
+
+            _lazyPages.Remove(placeholder);
+
+            await Task.Yield(); // allow UI to render before heavy load
+            var page = info.factory();
+            page.Title = placeholder.Title;
+            page.IconImageSource = info.icon;
+            var index = Children.IndexOf(placeholder);
+            Children[index] = page;
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove eager page instantiation from `MainTabsPage.xaml`
- lazily create tab pages in code-behind so switching tabs doesn't block the UI

## Testing
- `dotnet build -c Release` *(fails: NETSDK1147 workloads maui-tizen wasm-tools missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c225033f48330aad099dcb4fc819b