### PR TITLE
Add residual load tab

### DIFF
--- a/ChargePage.xaml
+++ b/ChargePage.xaml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MoleculeEfficienceTracker"
+    xmlns:chart="clr-namespace:Syncfusion.Maui.Charts;assembly=Syncfusion.Maui.Charts"
+    x:Class="MoleculeEfficienceTracker.ChargePage"
+    Title="Charge">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Styles/ModernStyles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <Color x:Key="MainBgColor">#F0F4F8</Color>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ContentPage.Background>
+        <SolidColorBrush Color="{StaticResource MainBgColor}" />
+    </ContentPage.Background>
+
+    <ScrollView>
+        <VerticalStackLayout Padding="10" Spacing="12">
+            <HorizontalStackLayout Spacing="10">
+                <Picker x:Name="PeriodPicker" Title="Période">
+                    <Picker.Items>
+                        <x:String>24h</x:String>
+                        <x:String>7j</x:String>
+                    </Picker.Items>
+                </Picker>
+            </HorizontalStackLayout>
+
+            <Frame Padding="10" CornerRadius="10" BackgroundColor="White" HasShadow="True" HeightRequest="300">
+                <chart:SfCartesianChart x:Name="LoadChart">
+                    <chart:SfCartesianChart.XAxes>
+                        <chart:DateTimeAxis LabelFormat="dd/MM HH" />
+                    </chart:SfCartesianChart.XAxes>
+                    <chart:SfCartesianChart.YAxes>
+                        <chart:NumericalAxis Minimum="0" />
+                    </chart:SfCartesianChart.YAxes>
+                </chart:SfCartesianChart>
+            </Frame>
+
+            <Label Text="Moyenne journalière" FontAttributes="Bold" />
+            <CollectionView x:Name="AverageCollection" HeightRequest="150">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid ColumnDefinitions="*,Auto" Padding="5">
+                            <Label Grid.Column="0" Text="{Binding MoleculeName}" />
+                            <Label Grid.Column="1" Text="{Binding Average, StringFormat='{0:F1} mg'}" />
+                        </Grid>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/ChargePage.xaml.cs
+++ b/ChargePage.xaml.cs
@@ -1,0 +1,67 @@
+using MoleculeEfficienceTracker.Core.Models;
+using MoleculeEfficienceTracker.Core.Services;
+using MoleculeEfficienceTracker.Core.Extensions;
+using Syncfusion.Maui.Charts;
+using Microsoft.Maui.Controls;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MoleculeEfficienceTracker
+{
+    public partial class ChargePage : ContentPage
+    {
+        private readonly IResidualLoadService _service = new ResidualLoadService();
+
+        public ObservableRangeCollection<ChartDataPoint> CaffeineData { get; } = new();
+        public ObservableRangeCollection<ChartDataPoint> BromazepamData { get; } = new();
+        public ObservableCollection<AverageEntry> Averages { get; } = new();
+
+        public ChargePage()
+        {
+            InitializeComponent();
+            BindingContext = this;
+            PeriodPicker.SelectedIndex = 1; // default 7j
+            PeriodPicker.SelectedIndexChanged += async (s, e) => await RefreshAsync();
+        }
+
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            await RefreshAsync();
+        }
+
+        private async Task RefreshAsync()
+        {
+            var days = PeriodPicker.SelectedIndex == 0 ? 1 : 7;
+            var end = DateTime.Now;
+            var start = end.AddDays(-days);
+            TimeSpan interval = days == 1 ? TimeSpan.FromHours(1) : TimeSpan.FromHours(6);
+
+            var caffeine = await _service.GetSnapshots("caffeine", start, end, interval);
+            var broma = await _service.GetSnapshots("bromazepam", start, end, interval);
+
+            CaffeineData.ReplaceRange(caffeine.Select(s => new ChartDataPoint(s.Timestamp, s.ResidualAmount)));
+            BromazepamData.ReplaceRange(broma.Select(s => new ChartDataPoint(s.Timestamp, s.ResidualAmount)));
+
+            LoadChart.Series.Clear();
+            LoadChart.Series.Add(new SplineSeries { ItemsSource = CaffeineData, XBindingPath = "Time", YBindingPath = "Concentration", StrokeWidth = 1.5, Label="Caféine" });
+            LoadChart.Series.Add(new SplineSeries { ItemsSource = BromazepamData, XBindingPath = "Time", YBindingPath = "Concentration", StrokeWidth = 1.5, Label="Bromazépam" });
+
+            Averages.Clear();
+            double avgCafe = await _service.GetAverageLoadPerDay("caffeine", days);
+            double avgBroma = await _service.GetAverageLoadPerDay("bromazepam", days);
+            Averages.Add(new AverageEntry { MoleculeName = "Caféine", Average = avgCafe });
+            Averages.Add(new AverageEntry { MoleculeName = "Bromazépam", Average = avgBroma });
+            AverageCollection.ItemsSource = Averages;
+        }
+
+        public class AverageEntry
+        {
+            public string MoleculeName { get; set; } = string.Empty;
+            public double Average { get; set; }
+        }
+    }
+}

--- a/Core/Models/ResidualLoadSnapshot.cs
+++ b/Core/Models/ResidualLoadSnapshot.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace MoleculeEfficienceTracker.Core.Models
+{
+    /// <summary>
+    /// Represents the estimated remaining amount of a molecule at a specific time.
+    /// </summary>
+    public class ResidualLoadSnapshot
+    {
+        public DateTime Timestamp { get; set; }
+        public string MoleculeName { get; set; } = string.Empty;
+        public double ResidualAmount { get; set; }
+
+        public ResidualLoadSnapshot() { }
+
+        public ResidualLoadSnapshot(DateTime timestamp, string moleculeName, double amount)
+        {
+            Timestamp = timestamp;
+            MoleculeName = moleculeName;
+            ResidualAmount = amount;
+        }
+    }
+}

--- a/Core/Services/IResidualLoadService.cs
+++ b/Core/Services/IResidualLoadService.cs
@@ -1,0 +1,11 @@
+using MoleculeEfficienceTracker.Core.Models;
+
+namespace MoleculeEfficienceTracker.Core.Services
+{
+    public interface IResidualLoadService
+    {
+        Task<IReadOnlyList<ResidualLoadSnapshot>> GetSnapshots(string moleculeKey, DateTime from, DateTime to, TimeSpan interval);
+        Task<IReadOnlyList<ResidualLoadSnapshot>> GetSnapshotsForAllMolecules(DateTime from, DateTime to, TimeSpan interval);
+        Task<double> GetAverageLoadPerDay(string moleculeKey, int lastNDays);
+    }
+}

--- a/Core/Services/ResidualLoadCalculator.cs
+++ b/Core/Services/ResidualLoadCalculator.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace MoleculeEfficienceTracker.Core.Services
+{
+    public static class ResidualLoadCalculator
+    {
+        /// <summary>
+        /// Returns the remaining amount of a molecule after a given time using its half-life.
+        /// Q(t) = Q0 * exp(-ln(2) * t / halfLife)
+        /// </summary>
+        public static double GetResidualAmount(double initialDose, double halfLifeHours, double hoursElapsed)
+        {
+            return initialDose * Math.Exp(-0.693 * hoursElapsed / halfLifeHours);
+        }
+    }
+}

--- a/Core/Services/ResidualLoadService.cs
+++ b/Core/Services/ResidualLoadService.cs
@@ -1,0 +1,74 @@
+using MoleculeEfficienceTracker.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MoleculeEfficienceTracker.Core.Services
+{
+    public class ResidualLoadService : IResidualLoadService
+    {
+        private readonly Dictionary<string, double> _halfLives = new()
+        {
+            ["caffeine"] = 5.0,
+            ["bromazepam"] = 14.0,
+            ["paracetamol"] = 2.5,
+            ["ibuprofene"] = 2.0,
+            ["ibuprofen"] = 2.0,
+            ["alcool"] = 1.0
+        };
+
+        private readonly Dictionary<string, DataPersistenceService> _persistence;
+
+        public ResidualLoadService()
+        {
+            _persistence = _halfLives.Keys.Distinct().ToDictionary(k => k, k => new DataPersistenceService(k));
+        }
+
+        public async Task<IReadOnlyList<ResidualLoadSnapshot>> GetSnapshots(string moleculeKey, DateTime from, DateTime to, TimeSpan interval)
+        {
+            if (!_halfLives.TryGetValue(moleculeKey.ToLowerInvariant(), out double halfLife))
+                return Array.Empty<ResidualLoadSnapshot>();
+
+            var doses = await _persistence[moleculeKey.ToLowerInvariant()].LoadDosesAsync();
+            return CalculateSnapshots(doses, moleculeKey, halfLife, from, to, interval).ToList();
+        }
+
+        public async Task<IReadOnlyList<ResidualLoadSnapshot>> GetSnapshotsForAllMolecules(DateTime from, DateTime to, TimeSpan interval)
+        {
+            var list = new List<ResidualLoadSnapshot>();
+            foreach (var kvp in _halfLives)
+            {
+                var doses = await _persistence[kvp.Key].LoadDosesAsync();
+                list.AddRange(CalculateSnapshots(doses, kvp.Key, kvp.Value, from, to, interval));
+            }
+            return list.OrderBy(s => s.Timestamp).ToList();
+        }
+
+        public async Task<double> GetAverageLoadPerDay(string moleculeKey, int lastNDays)
+        {
+            var end = DateTime.Now;
+            var start = end.AddDays(-lastNDays);
+            var snapshots = await GetSnapshots(moleculeKey, start, end, TimeSpan.FromHours(1));
+            var groups = snapshots.GroupBy(s => s.Timestamp.Date).Select(g => g.Average(x => x.ResidualAmount));
+            return groups.Any() ? groups.Average() : 0.0;
+        }
+
+        private static IEnumerable<ResidualLoadSnapshot> CalculateSnapshots(IEnumerable<DoseEntry> doses, string molecule, double halfLife, DateTime from, DateTime to, TimeSpan interval)
+        {
+            var snapshots = new List<ResidualLoadSnapshot>();
+            for (var t = from; t <= to; t = t.Add(interval))
+            {
+                double amount = 0;
+                foreach (var d in doses)
+                {
+                    double h = (t - d.TimeTaken).TotalHours;
+                    if (h >= 0)
+                        amount += ResidualLoadCalculator.GetResidualAmount(d.DoseMg, halfLife, h);
+                }
+                snapshots.Add(new ResidualLoadSnapshot(t, molecule, amount));
+            }
+            return snapshots;
+        }
+    }
+}

--- a/MainTabsPage.xaml
+++ b/MainTabsPage.xaml
@@ -13,6 +13,9 @@
     <!-- Onglet Anti-douleur -->
     <local:PainReliefPage Title="🩹" />
 
+<!-- Onglet Charge -->
+    <local:ChargePage Title="⚡" />
+
     <!-- Onglet Alcool -->
     <local:AlcoholPage Title="🍾" />
     <!-- Onglet Paramètres -->


### PR DESCRIPTION
## Summary
- add model to represent residual load snapshots
- create interface and service to compute residual loads
- add ChargePage with chart and daily averages
- hook new Charge tab into main tabs

## Testing
- `dotnet build --no-restore` *(fails: required workloads maui-tizen, wasm-tools, maui-android)*

------
https://chatgpt.com/codex/tasks/task_e_68513f412bf4833093c8490bd342e851