### PR TITLE
Add residual load tab

### DIFF
--- a/ChargePage.xaml
+++ b/ChargePage.xaml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="MoleculeEfficienceTracker.ChargePage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:chart="clr-namespace:Syncfusion.Maui.Charts;assembly=Syncfusion.Maui.Charts"
+    Title="Charge">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Styles/ModernStyles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <Color x:Key="MainBgColor">#F0F4F8</Color>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ContentPage.Background>
+        <SolidColorBrush Color="{StaticResource MainBgColor}" />
+    </ContentPage.Background>
+    <ScrollView>
+        <VerticalStackLayout Spacing="16" Padding="10">
+            <chart:SfCartesianChart x:Name="LoadChart" HeightRequest="300" />
+            <CollectionView x:Name="AverageCollection" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/ChargePage.xaml.cs
+++ b/ChargePage.xaml.cs
@@ -1,0 +1,62 @@
+using MoleculeEfficienceTracker.Core.Models;
+using MoleculeEfficienceTracker.Core.Services;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Syncfusion.Maui.Charts;
+
+namespace MoleculeEfficienceTracker;
+
+public partial class ChargePage : ContentPage
+{
+    private readonly IResidualLoadService _service = new ResidualLoadService();
+    private readonly Dictionary<string, ObservableCollection<ChartDataPoint>> _seriesData = new();
+
+    public ChargePage()
+    {
+        InitializeComponent();
+        BindingContext = this;
+        SetupChart();
+        LoadData();
+    }
+
+    private void SetupChart()
+    {
+        LoadChart.XAxes.Add(new DateTimeAxis());
+        LoadChart.YAxes.Add(new NumericalAxis());
+    }
+
+    private void LoadData()
+    {
+        DateTime end = DateTime.Now;
+        DateTime start = end.AddDays(-7);
+        TimeSpan step = TimeSpan.FromHours(3);
+        var snapshots = _service.GetSnapshotsForAllMolecules(start, end, step);
+        foreach (var group in snapshots.GroupBy(s => s.MoleculeName))
+        {
+            ObservableCollection<ChartDataPoint> list = new();
+            foreach (var snap in group)
+            {
+                list.Add(new ChartDataPoint(snap.Timestamp, snap.ResidualAmount));
+            }
+            _seriesData[group.Key] = list;
+        }
+        foreach (var kv in _seriesData)
+        {
+            LineSeries series = new()
+            {
+                ItemsSource = kv.Value,
+                XBindingPath = nameof(ChartDataPoint.Time),
+                YBindingPath = nameof(ChartDataPoint.Concentration),
+                Label = kv.Key
+            };
+            LoadChart.Series.Add(series);
+        }
+
+        var averages = _seriesData.Select(kv => new
+        {
+            Molecule = kv.Key,
+            Average = kv.Value.Any() ? kv.Value.Average(p => p.Concentration) : 0
+        }).ToList();
+        AverageCollection.ItemsSource = averages;
+    }
+}

--- a/Core/Models/ResidualLoadSnapshot.cs
+++ b/Core/Models/ResidualLoadSnapshot.cs
@@ -1,0 +1,17 @@
+namespace MoleculeEfficienceTracker.Core.Models;
+
+public class ResidualLoadSnapshot
+{
+    public DateTime Timestamp { get; set; }
+    public string MoleculeName { get; set; } = string.Empty;
+    public double ResidualAmount { get; set; }
+
+    public ResidualLoadSnapshot() {}
+
+    public ResidualLoadSnapshot(DateTime timestamp, string moleculeName, double residualAmount)
+    {
+        Timestamp = timestamp;
+        MoleculeName = moleculeName;
+        ResidualAmount = residualAmount;
+    }
+}

--- a/Core/Services/IResidualLoadService.cs
+++ b/Core/Services/IResidualLoadService.cs
@@ -1,0 +1,10 @@
+using MoleculeEfficienceTracker.Core.Models;
+
+namespace MoleculeEfficienceTracker.Core.Services;
+
+public interface IResidualLoadService
+{
+    IEnumerable<ResidualLoadSnapshot> GetSnapshots(string moleculeKey, DateTime from, DateTime to, TimeSpan interval);
+    IEnumerable<ResidualLoadSnapshot> GetSnapshotsForAllMolecules(DateTime from, DateTime to, TimeSpan interval);
+    double GetAverageLoadPerDay(string moleculeKey, int lastNDays);
+}

--- a/Core/Services/ResidualLoadService.cs
+++ b/Core/Services/ResidualLoadService.cs
@@ -1,0 +1,57 @@
+using MoleculeEfficienceTracker.Core.Models;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MoleculeEfficienceTracker.Core.Services;
+
+public class ResidualLoadService : IResidualLoadService
+{
+    private readonly Dictionary<string, (IMoleculeCalculator Calc, DataPersistenceService Persist)> _registry;
+
+    public ResidualLoadService()
+    {
+        _registry = new Dictionary<string, (IMoleculeCalculator, DataPersistenceService)>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["caffeine"] = (new CaffeineCalculator(), new DataPersistenceService("caffeine")),
+            ["bromazepam"] = (new BromazepamCalculator(), new DataPersistenceService("bromazepam")),
+            ["alcohol"] = (new AlcoholCalculator(), new DataPersistenceService("alcohol")),
+            ["paracetamol"] = (new ParacetamolCalculator(), new DataPersistenceService("paracetamol")),
+            ["ibuprofen"] = (new IbuprofeneCalculator(), new DataPersistenceService("ibuprofen"))
+        };
+    }
+
+    public IEnumerable<ResidualLoadSnapshot> GetSnapshots(string moleculeKey, DateTime from, DateTime to, TimeSpan interval)
+    {
+        if (!_registry.TryGetValue(moleculeKey, out var entry))
+            yield break;
+
+        List<DoseEntry> doses = entry.Persist.LoadDosesAsync().Result;
+        for (DateTime t = from; t <= to; t = t.Add(interval))
+        {
+            double amount = entry.Calc.CalculateTotalAmount(doses, t);
+            yield return new ResidualLoadSnapshot(t, moleculeKey, amount);
+        }
+    }
+
+    public IEnumerable<ResidualLoadSnapshot> GetSnapshotsForAllMolecules(DateTime from, DateTime to, TimeSpan interval)
+    {
+        foreach (var key in _registry.Keys)
+        {
+            foreach (var snap in GetSnapshots(key, from, to, interval))
+            {
+                yield return snap;
+            }
+        }
+    }
+
+    public double GetAverageLoadPerDay(string moleculeKey, int lastNDays)
+    {
+        DateTime end = DateTime.Now;
+        DateTime start = end.AddDays(-lastNDays);
+        TimeSpan step = TimeSpan.FromHours(1);
+        var snaps = GetSnapshots(moleculeKey, start, end, step).ToList();
+        if (snaps.Count == 0) return 0;
+        double avg = snaps.Average(s => s.ResidualAmount);
+        return avg;
+    }
+}

--- a/MainTabsPage.xaml
+++ b/MainTabsPage.xaml
@@ -15,6 +15,9 @@
 
     <!-- Onglet Alcool -->
     <local:AlcoholPage Title="🍾" />
+
+    <!-- Onglet Charge -->
+    <local:ChargePage Title="⚖️" />
     <!-- Onglet Paramètres -->
 
     <local:SettingsPage Title="⚙️" IconImageSource="⚙️" />


### PR DESCRIPTION
## Summary
- introduce residual load model and service
- display residual molecule load in a new Charge page
- expose Charge page from the main tabbed layout

## Testing
- `dotnet workload restore`
- `dotnet build -c Release` *(fails: missing workload packs)*

------
https://chatgpt.com/codex/tasks/task_e_68513f412bf4833093c8490bd342e851