### PR TITLE
Add advanced stats to ChargePage

### DIFF
--- a/ChargePage.xaml
+++ b/ChargePage.xaml
@@ -71,6 +71,51 @@
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>
+
+            <Label Text="Totaux quotidiens (7j)" FontAttributes="Bold" />
+            <Frame Padding="10" CornerRadius="10" BackgroundColor="White" HasShadow="True" HeightRequest="290">
+                <chart:SfCartesianChart x:Name="DailyTotalsChart7d">
+                    <chart:SfCartesianChart.XAxes>
+                        <chart:DateTimeAxis>
+                            <chart:DateTimeAxis.LabelStyle><chart:ChartAxisLabelStyle LabelFormat="dd/MM"/></chart:DateTimeAxis.LabelStyle>
+                        </chart:DateTimeAxis>
+                    </chart:SfCartesianChart.XAxes>
+                    <chart:SfCartesianChart.YAxes>
+                        <chart:NumericalAxis Minimum="0" />
+                    </chart:SfCartesianChart.YAxes>
+                </chart:SfCartesianChart>
+            </Frame>
+
+            <Label Text="Totaux quotidiens (30j)" FontAttributes="Bold" />
+            <Frame Padding="10" CornerRadius="10" BackgroundColor="White" HasShadow="True" HeightRequest="290">
+                <chart:SfCartesianChart x:Name="DailyTotalsChart30d">
+                    <chart:SfCartesianChart.XAxes>
+                        <chart:DateTimeAxis>
+                            <chart:DateTimeAxis.LabelStyle><chart:ChartAxisLabelStyle LabelFormat="dd/MM"/></chart:DateTimeAxis.LabelStyle>
+                        </chart:DateTimeAxis>
+                    </chart:SfCartesianChart.XAxes>
+                    <chart:SfCartesianChart.YAxes>
+                        <chart:NumericalAxis Minimum="0" />
+                    </chart:SfCartesianChart.YAxes>
+                </chart:SfCartesianChart>
+            </Frame>
+
+            <Label Text="Statistiques (30j)" FontAttributes="Bold" />
+            <CollectionView x:Name="StatsCollection30d" HeightRequest="180">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto,Auto" Padding="5">
+                            <Label Grid.Column="0" Text="{Binding MoleculeName}" />
+                            <Label Grid.Column="1" Text="{Binding AvgDose, StringFormat='{0:F1}'}" />
+                            <Label Grid.Column="2" Text="{Binding StdDose, StringFormat='{0:F1}'}" />
+                            <Label Grid.Column="3" Text="{Binding MinDose, StringFormat='{0:F1}'}" />
+                            <Label Grid.Column="4" Text="{Binding MaxDose, StringFormat='{0:F1}'}" />
+                            <Label Grid.Column="5" Text="{Binding AvgCount, StringFormat='{0:F1}'}" />
+                            <Label Grid.Column="6" Text="{Binding AvgInterval, StringFormat='{0:F1} h'}" />
+                        </Grid>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
         </VerticalStackLayout>
     </ScrollView>
 </ContentPage>

--- a/ChargePage.xaml
+++ b/ChargePage.xaml
@@ -23,6 +23,9 @@
             <Label Text="Charge sur 24h" FontAttributes="Bold" />
             <Frame Padding="10" CornerRadius="10" BackgroundColor="White" HasShadow="True" HeightRequest="290">
                 <chart:SfCartesianChart x:Name="Chart24h">
+                    <chart:SfCartesianChart.Legend>
+                        <chart:ChartLegend Placement="Bottom" />
+                    </chart:SfCartesianChart.Legend>
                     <chart:SfCartesianChart.XAxes>
                         <chart:DateTimeAxis>
                             <chart:DateTimeAxis.LabelStyle><chart:ChartAxisLabelStyle LabelFormat="HH:mm"/></chart:DateTimeAxis.LabelStyle>
@@ -49,6 +52,9 @@
             <Label Text="Charge sur 7 jours" FontAttributes="Bold" />
             <Frame Padding="10" CornerRadius="10" BackgroundColor="White" HasShadow="True" HeightRequest="290">
                 <chart:SfCartesianChart x:Name="Chart7d">
+                    <chart:SfCartesianChart.Legend>
+                        <chart:ChartLegend Placement="Bottom" />
+                    </chart:SfCartesianChart.Legend>
                     <chart:SfCartesianChart.XAxes>
                         <chart:DateTimeAxis>
                             <chart:DateTimeAxis.LabelStyle><chart:ChartAxisLabelStyle LabelFormat="dd/MM"/></chart:DateTimeAxis.LabelStyle>
@@ -75,6 +81,9 @@
             <Label Text="Totaux quotidiens (7j)" FontAttributes="Bold" />
             <Frame Padding="10" CornerRadius="10" BackgroundColor="White" HasShadow="True" HeightRequest="290">
                 <chart:SfCartesianChart x:Name="DailyTotalsChart7d">
+                    <chart:SfCartesianChart.Legend>
+                        <chart:ChartLegend Placement="Bottom" />
+                    </chart:SfCartesianChart.Legend>
                     <chart:SfCartesianChart.XAxes>
                         <chart:DateTimeAxis>
                             <chart:DateTimeAxis.LabelStyle><chart:ChartAxisLabelStyle LabelFormat="dd/MM"/></chart:DateTimeAxis.LabelStyle>
@@ -89,6 +98,9 @@
             <Label Text="Totaux quotidiens (30j)" FontAttributes="Bold" />
             <Frame Padding="10" CornerRadius="10" BackgroundColor="White" HasShadow="True" HeightRequest="290">
                 <chart:SfCartesianChart x:Name="DailyTotalsChart30d">
+                    <chart:SfCartesianChart.Legend>
+                        <chart:ChartLegend Placement="Bottom" />
+                    </chart:SfCartesianChart.Legend>
                     <chart:SfCartesianChart.XAxes>
                         <chart:DateTimeAxis>
                             <chart:DateTimeAxis.LabelStyle><chart:ChartAxisLabelStyle LabelFormat="dd/MM"/></chart:DateTimeAxis.LabelStyle>

--- a/ChargePage.xaml.cs
+++ b/ChargePage.xaml.cs
@@ -136,7 +136,7 @@ namespace MoleculeEfficienceTracker
                     YBindingPath = "Concentration",
                     StrokeWidth = 1.5,
                     Label = ToDisplayName(m),
-                    Stroke = _colors[m]
+                    Fill = _colors[m]
                 });
             }
         }
@@ -173,7 +173,7 @@ namespace MoleculeEfficienceTracker
                     XBindingPath = "Time",
                     YBindingPath = "Concentration",
                     StrokeWidth = 1,
-                    Stroke = _colors[m],
+                    Fill = _colors[m],
                     Label = ToDisplayName(m) + " trend",
                     IsVisibleOnLegend = false
                 });

--- a/ChargePage.xaml.cs
+++ b/ChargePage.xaml.cs
@@ -17,6 +17,15 @@ namespace MoleculeEfficienceTracker
 
         private readonly string[] _molecules = new[] { "caffeine", "bromazepam", "paracetamol", "ibuprofene", "alcool" };
 
+        private readonly Dictionary<string, Color> _colors = new()
+        {
+            ["caffeine"] = Color.FromArgb("#ff7f0e"),
+            ["bromazepam"] = Color.FromArgb("#1f77b4"),
+            ["paracetamol"] = Color.FromArgb("#2ca02c"),
+            ["ibuprofene"] = Color.FromArgb("#9467bd"),
+            ["alcool"] = Color.FromArgb("#d62728")
+        };
+
         private readonly Dictionary<string, ObservableRangeCollection<ChartDataPoint>> _data24h = new();
         private readonly Dictionary<string, ObservableRangeCollection<ChartDataPoint>> _data7d = new();
         private readonly Dictionary<string, ObservableRangeCollection<ChartDataPoint>> _dailyTotals7d = new();
@@ -126,7 +135,8 @@ namespace MoleculeEfficienceTracker
                     XBindingPath = "Time",
                     YBindingPath = "Concentration",
                     StrokeWidth = 1.5,
-                    Label = ToDisplayName(m)
+                    Label = ToDisplayName(m),
+                    Stroke = _colors[m]
                 });
             }
         }
@@ -152,7 +162,8 @@ namespace MoleculeEfficienceTracker
                     XBindingPath = "Time",
                     YBindingPath = "Concentration",
                     Label = ToDisplayName(m),
-                    StrokeWidth = 1
+                    StrokeWidth = 1,
+                    Fill = _colors[m]
                 });
 
                 var avgPoints = CalculateMovingAverage(source[m].Select(p => p.Concentration).ToList(), 3);
@@ -162,6 +173,7 @@ namespace MoleculeEfficienceTracker
                     XBindingPath = "Time",
                     YBindingPath = "Concentration",
                     StrokeWidth = 1,
+                    Stroke = _colors[m],
                     Label = ToDisplayName(m) + " trend",
                     IsVisibleOnLegend = false
                 });

--- a/ChargePage.xaml.cs
+++ b/ChargePage.xaml.cs
@@ -19,9 +19,14 @@ namespace MoleculeEfficienceTracker
 
         private readonly Dictionary<string, ObservableRangeCollection<ChartDataPoint>> _data24h = new();
         private readonly Dictionary<string, ObservableRangeCollection<ChartDataPoint>> _data7d = new();
+        private readonly Dictionary<string, ObservableRangeCollection<ChartDataPoint>> _dailyTotals7d = new();
+        private readonly Dictionary<string, ObservableRangeCollection<ChartDataPoint>> _dailyTotals30d = new();
 
         public ObservableCollection<AverageEntry> Averages7j { get; } = new();
         public ObservableCollection<AverageEntry> Averages24h { get; } = new();
+        public ObservableCollection<StatsEntry> Stats30d { get; } = new();
+
+        private readonly UsageStatsService _statsService;
 
         public ChargePage()
         {
@@ -32,7 +37,11 @@ namespace MoleculeEfficienceTracker
             {
                 _data24h[m] = new ObservableRangeCollection<ChartDataPoint>();
                 _data7d[m] = new ObservableRangeCollection<ChartDataPoint>();
+                _dailyTotals7d[m] = new ObservableRangeCollection<ChartDataPoint>();
+                _dailyTotals30d[m] = new ObservableRangeCollection<ChartDataPoint>();
             }
+
+            _statsService = new UsageStatsService(_molecules);
         }
 
         protected override async void OnAppearing()
@@ -48,8 +57,13 @@ namespace MoleculeEfficienceTracker
             await LoadPeriodAsync(now.AddDays(-1), now, TimeSpan.FromHours(1), _data24h);
             await LoadPeriodAsync(now.AddDays(-7), now, TimeSpan.FromHours(6), _data7d);
 
+            await LoadDailyTotalsAsync(now.AddDays(-7).Date, now.Date, _dailyTotals7d);
+            await LoadDailyTotalsAsync(now.AddDays(-30).Date, now.Date, _dailyTotals30d);
+
             UpdateChart(Chart24h, _data24h);
             UpdateChart(Chart7d, _data7d);
+            UpdateColumnChart(DailyTotalsChart7d, _dailyTotals7d);
+            UpdateColumnChart(DailyTotalsChart30d, _dailyTotals30d);
 
             Averages24h.Clear();
             Averages7j.Clear();
@@ -65,8 +79,30 @@ namespace MoleculeEfficienceTracker
                 Averages7j.Add(new AverageEntry { MoleculeName = ToDisplayName(m), Average = avg });
             }
 
+            Stats30d.Clear();
+            foreach (var m in _molecules)
+            {
+                var daily = await _statsService.GetDailyStatsAsync(m, 30);
+                var doseStats = UsageStatsService.ComputeStats(daily.Select(d => d.TotalDose));
+                var countStats = UsageStatsService.ComputeStats(daily.Select(d => (double)d.Count));
+                var doses = await _statsService.GetDosesAsync(m, now.AddDays(-30), now);
+                double avgInterval = UsageStatsService.ComputeAverageIntervalHours(doses);
+                Stats30d.Add(new StatsEntry
+                {
+                    MoleculeName = ToDisplayName(m),
+                    AvgDose = doseStats.mean,
+                    StdDose = doseStats.stdDev,
+                    MinDose = doseStats.min,
+                    MaxDose = doseStats.max,
+                    AvgCount = countStats.mean,
+                    StdCount = countStats.stdDev,
+                    AvgInterval = avgInterval
+                });
+            }
+
             AverageCollection24h.ItemsSource = Averages24h;
             AverageCollection7j.ItemsSource = Averages7j;
+            StatsCollection30d.ItemsSource = Stats30d;
         }
 
         private async Task LoadPeriodAsync(DateTime from, DateTime to, TimeSpan interval,
@@ -95,6 +131,55 @@ namespace MoleculeEfficienceTracker
             }
         }
 
+        private async Task LoadDailyTotalsAsync(DateTime from, DateTime to, Dictionary<string, ObservableRangeCollection<ChartDataPoint>> target)
+        {
+            int days = (int)(to - from).TotalDays + 1;
+            foreach (var m in _molecules)
+            {
+                var stats = await _statsService.GetDailyStatsAsync(m, days);
+                target[m].ReplaceRange(stats.Select(s => new ChartDataPoint(s.Date, s.TotalDose)));
+            }
+        }
+
+        private void UpdateColumnChart(SfCartesianChart chart, Dictionary<string, ObservableRangeCollection<ChartDataPoint>> source)
+        {
+            chart.Series.Clear();
+            foreach (var m in _molecules)
+            {
+                chart.Series.Add(new ColumnSeries
+                {
+                    ItemsSource = source[m],
+                    XBindingPath = "Time",
+                    YBindingPath = "Concentration",
+                    Label = ToDisplayName(m),
+                    StrokeWidth = 1
+                });
+
+                var avgPoints = CalculateMovingAverage(source[m].Select(p => p.Concentration).ToList(), 3);
+                chart.Series.Add(new LineSeries
+                {
+                    ItemsSource = source[m].Select((p, i) => new ChartDataPoint(p.Time, avgPoints[i])),
+                    XBindingPath = "Time",
+                    YBindingPath = "Concentration",
+                    StrokeWidth = 1,
+                    Label = ToDisplayName(m) + " trend",
+                    IsVisibleOnLegend = false
+                });
+            }
+        }
+
+        private static List<double> CalculateMovingAverage(IList<double> values, int window)
+        {
+            var result = new List<double>();
+            for (int i = 0; i < values.Count; i++)
+            {
+                int start = Math.Max(0, i - window + 1);
+                var slice = values.Skip(start).Take(i - start + 1);
+                result.Add(slice.Average());
+            }
+            return result;
+        }
+
         private static string ToDisplayName(string key) => key switch
         {
             "caffeine" => "Caféine",
@@ -109,6 +194,18 @@ namespace MoleculeEfficienceTracker
         {
             public string MoleculeName { get; set; } = string.Empty;
             public double Average { get; set; }
+        }
+
+        public class StatsEntry
+        {
+            public string MoleculeName { get; set; } = string.Empty;
+            public double AvgDose { get; set; }
+            public double StdDose { get; set; }
+            public double MinDose { get; set; }
+            public double MaxDose { get; set; }
+            public double AvgCount { get; set; }
+            public double StdCount { get; set; }
+            public double AvgInterval { get; set; }
         }
     }
 }

--- a/Core/Services/UsageStatsService.cs
+++ b/Core/Services/UsageStatsService.cs
@@ -1,0 +1,109 @@
+using MoleculeEfficienceTracker.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MoleculeEfficienceTracker.Core.Services
+{
+    public class DailyStats
+    {
+        public DateTime Date { get; set; }
+        public double TotalDose { get; set; }
+        public int Count { get; set; }
+    }
+
+    public class PeakInfo
+    {
+        public double PeakAmount { get; set; }
+        public DateTime PeakTime { get; set; }
+        public double HoursAboveThreshold { get; set; }
+    }
+
+    public class UsageStatsService
+    {
+        private readonly Dictionary<string, DataPersistenceService> _persistence;
+        private readonly IResidualLoadService _residualService = new ResidualLoadService();
+
+        public UsageStatsService(IEnumerable<string> moleculeKeys)
+        {
+            _persistence = moleculeKeys.ToDictionary(k => k.ToLowerInvariant(), k => new DataPersistenceService(k));
+        }
+
+        public async Task<List<DoseEntry>> GetDosesAsync(string key, DateTime start, DateTime end)
+        {
+            key = key.ToLowerInvariant();
+            if (!_persistence.ContainsKey(key)) return new List<DoseEntry>();
+            var doses = await _persistence[key].LoadDosesAsync();
+            return doses.Where(d => d.TimeTaken >= start && d.TimeTaken <= end).OrderBy(d => d.TimeTaken).ToList();
+        }
+
+        public async Task<List<DailyStats>> GetDailyStatsAsync(string key, int days)
+        {
+            key = key.ToLowerInvariant();
+            if (!_persistence.ContainsKey(key)) return new List<DailyStats>();
+
+            DateTime end = DateTime.Now.Date;
+            DateTime start = end.AddDays(-days + 1);
+
+            var doses = await _persistence[key].LoadDosesAsync();
+            var relevant = doses.Where(d => d.TimeTaken.Date >= start && d.TimeTaken.Date <= end);
+
+            var grouped = relevant.GroupBy(d => d.TimeTaken.Date)
+                                  .ToDictionary(g => g.Key,
+                                                g => new DailyStats
+                                                {
+                                                    Date = g.Key,
+                                                    TotalDose = g.Sum(x => x.DoseMg),
+                                                    Count = g.Count()
+                                                });
+            var list = new List<DailyStats>();
+            for (DateTime d = start; d <= end; d = d.AddDays(1))
+            {
+                if (grouped.TryGetValue(d, out var val))
+                    list.Add(val);
+                else
+                    list.Add(new DailyStats { Date = d, TotalDose = 0, Count = 0 });
+            }
+            return list;
+        }
+
+        public static (double mean, double stdDev, double min, double max) ComputeStats(IEnumerable<double> values)
+        {
+            var arr = values.ToList();
+            if (!arr.Any()) return (0, 0, 0, 0);
+            double mean = arr.Average();
+            double min = arr.Min();
+            double max = arr.Max();
+            double variance = arr.Sum(v => Math.Pow(v - mean, 2)) / arr.Count;
+            double sd = Math.Sqrt(variance);
+            return (mean, sd, min, max);
+        }
+
+        public static double ComputeAverageIntervalHours(IEnumerable<DoseEntry> doses)
+        {
+            var ordered = doses.OrderBy(d => d.TimeTaken).ToList();
+            if (ordered.Count < 2) return double.NaN;
+            var intervals = ordered.Zip(ordered.Skip(1), (a, b) => (b.TimeTaken - a.TimeTaken).TotalHours);
+            return intervals.Average();
+        }
+
+        public async Task<PeakInfo> GetPeakInfoAsync(string key, DateTime from, DateTime to, double threshold)
+        {
+            var snapshots = await _residualService.GetSnapshots(key, from, to, TimeSpan.FromHours(1));
+            if (snapshots.Count == 0)
+                return new PeakInfo { PeakAmount = 0, PeakTime = from, HoursAboveThreshold = 0 };
+
+            var peak = snapshots.OrderByDescending(s => s.ResidualAmount).First();
+            double hours = 0;
+            for (int i = 1; i < snapshots.Count; i++)
+            {
+                if (snapshots[i - 1].ResidualAmount >= threshold)
+                {
+                    hours += (snapshots[i].Timestamp - snapshots[i - 1].Timestamp).TotalHours;
+                }
+            }
+            return new PeakInfo { PeakAmount = peak.ResidualAmount, PeakTime = peak.Timestamp, HoursAboveThreshold = hours };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `UsageStatsService` for advanced consumption analytics
- expand `ChargePage` with daily totals, moving averages and stat table
- show charts for 7-day and 30-day daily totals

## Testing
- `dotnet build --no-restore` *(fails: maui workloads missing)*

------
https://chatgpt.com/codex/tasks/task_e_685177464cf88330be0fe79fce642fad