### PR TITLE
Modernize ChargePage UI

### DIFF
--- a/ChargePage.xaml
+++ b/ChargePage.xaml
@@ -19,95 +19,142 @@
     </ContentPage.Background>
 
     <ScrollView>
-        <VerticalStackLayout Padding="10"
-                             Spacing="12">
-            <Label Text="Moyennes journalières"
-                   FontAttributes="Bold"/>
+        <VerticalStackLayout Style="{StaticResource PageRootLayoutStyle}"
+                             BackgroundColor="{StaticResource MainBgColor}">
+            <Label Text="📊 Moyennes journalières"
+                   Style="{StaticResource CompactHeaderStyle}"/>
 
-            <Label Text="24h"
-                   FontAttributes="Bold"/>
-            <CollectionView x:Name="StatsCollection1d"
-                            HeightRequest="220">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate>
-                        <Grid ColumnDefinitions="2*,Auto,Auto,Auto,Auto"
-                              ColumnSpacing="8"
-                              Padding="6">
-                            <Label Grid.Column="0"
-                                   Text="{Binding MoleculeName}"
-                                   FontAttributes="Bold"/>
-                            <Label Grid.Column="1"
-                                   Text="{Binding AvgDose, StringFormat='{}{0:F1}mg'}"/>
-                            <Label Grid.Column="2"
-                                   Text="{Binding AvgCount, StringFormat='{}{0:F1}prises'}"/>
-                            <Label Grid.Column="3"
-                                   Text="{Binding VariationText}"
-                                   FontAttributes="Bold"/>
-                            <!-- Optionnel : -->
-                            <!-- <Label Grid.Column="4"
-                                   Text="{Binding PeakInfoText}"
-                                   FontSize="10"/> -->
-                        </Grid>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
+            <!-- Bloc 24h -->
+            <Frame Style="{StaticResource CardFrameStyle}">
+                <VerticalStackLayout Spacing="6">
+                    <Label Text="⏱️ Dernières 24h"
+                           FontAttributes="Bold"
+                           TextColor="{StaticResource Primary}"/>
+                    <CollectionView x:Name="StatsCollection1d"
+                                    ItemsSource="{Binding Stats1d}"
+                                    SelectionMode="None">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate>
+                                <Frame CornerRadius="8"
+                                       Padding="8"
+                                       Margin="0,2"
+                                       BackgroundColor="White"
+                                       HasShadow="True">
+                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto"
+                                          ColumnSpacing="10"
+                                          VerticalOptions="Center">
+                                        <Label Grid.Column="0"
+                                               Text="{Binding Icon}"
+                                               FontSize="18"
+                                               VerticalOptions="Center"/>
+                                        <Label Grid.Column="1"
+                                               Text="{Binding MoleculeName}"
+                                               FontAttributes="Bold"
+                                               VerticalOptions="Center"/>
+                                        <Label Grid.Column="2"
+                                               Text="{Binding AvgDose, StringFormat='{0:F1} mg'}"
+                                               HorizontalOptions="End"
+                                               FontAttributes="Bold"/>
+                                        <Label Grid.Column="3"
+                                               Text="{Binding VariationText}"
+                                               TextColor="{Binding VariationColor}"
+                                               HorizontalOptions="End"
+                                               FontAttributes="Bold"/>
+                                    </Grid>
+                                </Frame>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </VerticalStackLayout>
+            </Frame>
 
-            <Label Text="7 jours"
-                   FontAttributes="Bold"/>
-            <CollectionView x:Name="StatsCollection7d"
-                            HeightRequest="220">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate>
-                        <Grid ColumnDefinitions="2*,Auto,Auto,Auto,Auto"
-                              ColumnSpacing="8"
-                              Padding="6">
-                            <Label Grid.Column="0"
-                                   Text="{Binding MoleculeName}"
-                                   FontAttributes="Bold"/>
-                            <Label Grid.Column="1"
-                                   Text="{Binding AvgDose, StringFormat='{}{0:F1}mg'}"/>
-                            <Label Grid.Column="2"
-                                   Text="{Binding AvgCount, StringFormat='{}{0:F1}prises'}"/>
-                            <Label Grid.Column="3"
-                                   Text="{Binding VariationText}"
-                                   FontAttributes="Bold"/>
-                            <!-- Optionnel : -->
-                            <!-- <Label Grid.Column="4"
-                                   Text="{Binding PeakInfoText}"
-                                   FontSize="10"/> -->
-                        </Grid>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
+            <!-- Bloc 7 jours -->
+            <Frame Style="{StaticResource CardFrameStyle}">
+                <VerticalStackLayout Spacing="6">
+                    <Label Text="📅 7 derniers jours"
+                           FontAttributes="Bold"
+                           TextColor="{StaticResource Primary}"/>
+                    <CollectionView x:Name="StatsCollection7d"
+                                    ItemsSource="{Binding Stats7d}"
+                                    SelectionMode="None">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate>
+                                <Frame CornerRadius="8"
+                                       Padding="8"
+                                       Margin="0,2"
+                                       BackgroundColor="White"
+                                       HasShadow="True">
+                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto"
+                                          ColumnSpacing="10"
+                                          VerticalOptions="Center">
+                                        <Label Grid.Column="0"
+                                               Text="{Binding Icon}"
+                                               FontSize="18"
+                                               VerticalOptions="Center"/>
+                                        <Label Grid.Column="1"
+                                               Text="{Binding MoleculeName}"
+                                               FontAttributes="Bold"
+                                               VerticalOptions="Center"/>
+                                        <Label Grid.Column="2"
+                                               Text="{Binding AvgDose, StringFormat='{0:F1} mg'}"
+                                               HorizontalOptions="End"
+                                               FontAttributes="Bold"/>
+                                        <Label Grid.Column="3"
+                                               Text="{Binding VariationText}"
+                                               TextColor="{Binding VariationColor}"
+                                               HorizontalOptions="End"
+                                               FontAttributes="Bold"/>
+                                    </Grid>
+                                </Frame>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </VerticalStackLayout>
+            </Frame>
 
-
-            <Label Text="30 jours"
-                   FontAttributes="Bold"/>
-            <CollectionView x:Name="StatsCollection30d"
-                            HeightRequest="220">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate>
-                        <Grid ColumnDefinitions="2*,Auto,Auto,Auto,Auto"
-                              ColumnSpacing="8"
-                              Padding="6">
-                            <Label Grid.Column="0"
-                                   Text="{Binding MoleculeName}"
-                                   FontAttributes="Bold"/>
-                            <Label Grid.Column="1"
-                                   Text="{Binding AvgDose, StringFormat='{}{0:F1}mg'}"/>
-                            <Label Grid.Column="2"
-                                   Text="{Binding AvgCount, StringFormat='{}{0:F1}prises'}"/>
-                            <Label Grid.Column="3"
-                                   Text="{Binding VariationText}"
-                                   FontAttributes="Bold"/>
-                            <!-- Optionnel : -->
-                            <!-- <Label Grid.Column="4"
-                                    Text="{Binding PeakInfoText}"
-                                    FontSize="10"/> -->
-                        </Grid>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
+            <!-- Bloc 30 jours -->
+            <Frame Style="{StaticResource CardFrameStyle}">
+                <VerticalStackLayout Spacing="6">
+                    <Label Text="🗓️ 30 derniers jours"
+                           FontAttributes="Bold"
+                           TextColor="{StaticResource Primary}"/>
+                    <CollectionView x:Name="StatsCollection30d"
+                                    ItemsSource="{Binding Stats30d}"
+                                    SelectionMode="None">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate>
+                                <Frame CornerRadius="8"
+                                       Padding="8"
+                                       Margin="0,2"
+                                       BackgroundColor="White"
+                                       HasShadow="True">
+                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto"
+                                          ColumnSpacing="10"
+                                          VerticalOptions="Center">
+                                        <Label Grid.Column="0"
+                                               Text="{Binding Icon}"
+                                               FontSize="18"
+                                               VerticalOptions="Center"/>
+                                        <Label Grid.Column="1"
+                                               Text="{Binding MoleculeName}"
+                                               FontAttributes="Bold"
+                                               VerticalOptions="Center"/>
+                                        <Label Grid.Column="2"
+                                               Text="{Binding AvgDose, StringFormat='{0:F1} mg'}"
+                                               HorizontalOptions="End"
+                                               FontAttributes="Bold"/>
+                                        <Label Grid.Column="3"
+                                               Text="{Binding VariationText}"
+                                               TextColor="{Binding VariationColor}"
+                                               HorizontalOptions="End"
+                                               FontAttributes="Bold"/>
+                                    </Grid>
+                                </Frame>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </VerticalStackLayout>
+            </Frame>
 
         </VerticalStackLayout>
     </ScrollView>

--- a/ChargePage.xaml.cs
+++ b/ChargePage.xaml.cs
@@ -3,6 +3,7 @@ using MoleculeEfficienceTracker.Core.Services;
 using MoleculeEfficienceTracker.Core.Extensions;
 using Syncfusion.Maui.Charts;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -24,6 +25,15 @@ namespace MoleculeEfficienceTracker
             ["paracetamol"] = Color.FromArgb("#2ca02c"),
             ["ibuprofene"] = Color.FromArgb("#9467bd"),
             ["alcool"] = Color.FromArgb("#d62728")
+        };
+
+        private readonly Dictionary<string, string> _icons = new()
+        {
+            ["caffeine"] = "🍵",
+            ["bromazepam"] = "💊",
+            ["paracetamol"] = "💊",
+            ["ibuprofene"] = "💊",
+            ["alcool"] = "🍾"
         };
 
         private readonly Dictionary<string, double> _lightThresholds = new()
@@ -241,6 +251,7 @@ namespace MoleculeEfficienceTracker
             return new StatsEntry
             {
                 MoleculeName = ToDisplayName(molecule),
+                Icon = _icons[molecule],
                 PeriodDays = days,
                 AvgDose = doseStats.mean,      // ← devient moyenne journalière
                 StdDose = doseStats.stdDev,
@@ -277,6 +288,7 @@ namespace MoleculeEfficienceTracker
 
         public class StatsEntry
         {
+            public string Icon { get; set; } = string.Empty;
             public string MoleculeName { get; set; } = string.Empty;
             public int PeriodDays { get; set; }
             public double AvgDose { get; set; }
@@ -297,6 +309,11 @@ namespace MoleculeEfficienceTracker
                 : VariationPercent > 0 ? $"▲ {VariationPercent:F1}%"
                 : VariationPercent < 0 ? $"▼ {Math.Abs(VariationPercent):F1}%"
                 : "➖ 0%";
+            public Color VariationColor => double.IsNaN(VariationPercent)
+                ? Colors.Gray
+                : VariationPercent > 0 ? Colors.Red
+                : VariationPercent < 0 ? Colors.Green
+                : Colors.Gray;
             public string PeakInfoText =>
                 $"Pic {Peak:F1} le {PeakTime:dd/MM HH:mm}, {HoursAboveThreshold:F1} h > seuil";
         }


### PR DESCRIPTION
## Summary
- restyle ChargePage with cards and soft colors
- show emoji icons and colored trend labels
- expose icon and variation color from code-behind

## Testing
- `dotnet build -nologo` *(fails: InternalLoggerException)*

------
https://chatgpt.com/codex/tasks/task_e_685289a348508330b9baaff560d63c32