### PR TITLE
Modernize ChargePage with Samsung Health styling

### DIFF
--- a/ChargePage.xaml
+++ b/ChargePage.xaml
@@ -22,7 +22,9 @@
         <VerticalStackLayout Style="{StaticResource PageRootLayoutStyle}"
                              BackgroundColor="{StaticResource MainBgColor}">
             <Label Text="📊 Moyennes journalières"
-                   Style="{StaticResource CompactHeaderStyle}"/>
+                   FontAttributes="Bold"
+                   FontSize="24"
+                   TextColor="{StaticResource Primary}"/>
 
             <!-- Bloc 24h -->
             <Frame Style="{StaticResource CardFrameStyle}">
@@ -35,31 +37,38 @@
                                     SelectionMode="None">
                         <CollectionView.ItemTemplate>
                             <DataTemplate>
-                                <Frame CornerRadius="8"
+                                <Frame CornerRadius="12"
                                        Padding="8"
                                        Margin="0,2"
                                        BackgroundColor="White"
                                        HasShadow="True">
-                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto"
+                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto" RowDefinitions="Auto,Auto"
                                           ColumnSpacing="10"
+                                          RowSpacing="4"
                                           VerticalOptions="Center">
-                                        <Label Grid.Column="0"
+                                        <Label Grid.Row="0" Grid.Column="0"
                                                Text="{Binding Icon}"
                                                FontSize="18"
                                                VerticalOptions="Center"/>
-                                        <Label Grid.Column="1"
+                                        <Label Grid.Row="0" Grid.Column="1"
                                                Text="{Binding MoleculeName}"
                                                FontAttributes="Bold"
                                                VerticalOptions="Center"/>
-                                        <Label Grid.Column="2"
+                                        <Label Grid.Row="0" Grid.Column="2"
                                                Text="{Binding AvgDose, StringFormat='{0:F1} mg'}"
                                                HorizontalOptions="End"
                                                FontAttributes="Bold"/>
-                                        <Label Grid.Column="3"
+                                        <Label Grid.Row="0" Grid.Column="3"
                                                Text="{Binding VariationText}"
                                                TextColor="{Binding VariationColor}"
                                                HorizontalOptions="End"
                                                FontAttributes="Bold"/>
+                                        <ProgressBar Grid.Row="1" Grid.ColumnSpan="4"
+                                                     Progress="{Binding ProgressRatio}"
+                                                     ProgressColor="{Binding ProgressColor}"
+                                                     BackgroundColor="#E5E7EB"
+                                                     HeightRequest="6"
+                                                     Margin="0,4,0,0"/>
                                     </Grid>
                                 </Frame>
                             </DataTemplate>
@@ -79,31 +88,38 @@
                                     SelectionMode="None">
                         <CollectionView.ItemTemplate>
                             <DataTemplate>
-                                <Frame CornerRadius="8"
+                                <Frame CornerRadius="12"
                                        Padding="8"
                                        Margin="0,2"
                                        BackgroundColor="White"
                                        HasShadow="True">
-                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto"
+                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto" RowDefinitions="Auto,Auto"
                                           ColumnSpacing="10"
+                                          RowSpacing="4"
                                           VerticalOptions="Center">
-                                        <Label Grid.Column="0"
+                                        <Label Grid.Row="0" Grid.Column="0"
                                                Text="{Binding Icon}"
                                                FontSize="18"
                                                VerticalOptions="Center"/>
-                                        <Label Grid.Column="1"
+                                        <Label Grid.Row="0" Grid.Column="1"
                                                Text="{Binding MoleculeName}"
                                                FontAttributes="Bold"
                                                VerticalOptions="Center"/>
-                                        <Label Grid.Column="2"
+                                        <Label Grid.Row="0" Grid.Column="2"
                                                Text="{Binding AvgDose, StringFormat='{0:F1} mg'}"
                                                HorizontalOptions="End"
                                                FontAttributes="Bold"/>
-                                        <Label Grid.Column="3"
+                                        <Label Grid.Row="0" Grid.Column="3"
                                                Text="{Binding VariationText}"
                                                TextColor="{Binding VariationColor}"
                                                HorizontalOptions="End"
                                                FontAttributes="Bold"/>
+                                        <ProgressBar Grid.Row="1" Grid.ColumnSpan="4"
+                                                     Progress="{Binding ProgressRatio}"
+                                                     ProgressColor="{Binding ProgressColor}"
+                                                     BackgroundColor="#E5E7EB"
+                                                     HeightRequest="6"
+                                                     Margin="0,4,0,0"/>
                                     </Grid>
                                 </Frame>
                             </DataTemplate>
@@ -123,31 +139,38 @@
                                     SelectionMode="None">
                         <CollectionView.ItemTemplate>
                             <DataTemplate>
-                                <Frame CornerRadius="8"
+                                <Frame CornerRadius="12"
                                        Padding="8"
                                        Margin="0,2"
                                        BackgroundColor="White"
                                        HasShadow="True">
-                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto"
+                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto" RowDefinitions="Auto,Auto"
                                           ColumnSpacing="10"
+                                          RowSpacing="4"
                                           VerticalOptions="Center">
-                                        <Label Grid.Column="0"
+                                        <Label Grid.Row="0" Grid.Column="0"
                                                Text="{Binding Icon}"
                                                FontSize="18"
                                                VerticalOptions="Center"/>
-                                        <Label Grid.Column="1"
+                                        <Label Grid.Row="0" Grid.Column="1"
                                                Text="{Binding MoleculeName}"
                                                FontAttributes="Bold"
                                                VerticalOptions="Center"/>
-                                        <Label Grid.Column="2"
+                                        <Label Grid.Row="0" Grid.Column="2"
                                                Text="{Binding AvgDose, StringFormat='{0:F1} mg'}"
                                                HorizontalOptions="End"
                                                FontAttributes="Bold"/>
-                                        <Label Grid.Column="3"
+                                        <Label Grid.Row="0" Grid.Column="3"
                                                Text="{Binding VariationText}"
                                                TextColor="{Binding VariationColor}"
                                                HorizontalOptions="End"
                                                FontAttributes="Bold"/>
+                                        <ProgressBar Grid.Row="1" Grid.ColumnSpan="4"
+                                                     Progress="{Binding ProgressRatio}"
+                                                     ProgressColor="{Binding ProgressColor}"
+                                                     BackgroundColor="#E5E7EB"
+                                                     HeightRequest="6"
+                                                     Margin="0,4,0,0"/>
                                     </Grid>
                                 </Frame>
                             </DataTemplate>

--- a/ChargePage.xaml.cs
+++ b/ChargePage.xaml.cs
@@ -265,7 +265,8 @@ namespace MoleculeEfficienceTracker
                 VariationPercent = variation,
                 Peak = peak.PeakAmount,
                 PeakTime = peak.PeakTime,
-                HoursAboveThreshold = peak.HoursAboveThreshold
+                HoursAboveThreshold = peak.HoursAboveThreshold,
+                Threshold = threshold
             };
         }
 
@@ -304,6 +305,11 @@ namespace MoleculeEfficienceTracker
             public double Peak { get; set; }
             public DateTime PeakTime { get; set; }
             public double HoursAboveThreshold { get; set; }
+            public double Threshold { get; set; }
+            public double ProgressRatio => Threshold > 0 ? Math.Min(AvgDose / Threshold, 1) : 0;
+            public Color ProgressColor =>
+                ProgressRatio < 0.5 ? Colors.Green :
+                ProgressRatio < 1 ? Colors.Orange : Colors.Red;
             public string VariationText => double.IsNaN(VariationPercent)
                 ? "N/A"
                 : VariationPercent > 0 ? $"▲ {VariationPercent:F1}%"


### PR DESCRIPTION
## Summary
- redesign ChargePage header and cards using larger fonts, rounded frames and progress bars
- compute threshold progress for each molecule
- expose progress ratio and color via new properties

## Testing
- `dotnet build -c Release` *(fails: missing Microsoft.MacCatalyst.Sdk workload)*

------
https://chatgpt.com/codex/tasks/task_e_6852966ab8348330864f88284929f824